### PR TITLE
Fix serve startup issues

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,8 +25,8 @@
             "mode": "auto",
             "program": "${workspaceFolder}/agent/main.go",
             "args": [
-                "serve",                
-                "-v"
+                "serve",   
+                "-v"             
             ],
             "envFile": "${workspaceFolder}/.env"
         },

--- a/agent/cmd/relay.go
+++ b/agent/cmd/relay.go
@@ -73,7 +73,7 @@ var RelayCommand = &cobra.Command{
 func init() {
 	RelayCommand.Flags().StringP("accept-file", "f", "", "Accept.json file detailing which APIs are allowed to be relayed")
 	RelayCommand.Flags().StringP("integration", "i", "", fmt.Sprintf("Integration to use for relaying, allowed values are: %v", common.ValidIntegrations()))
-	RelayCommand.Flags().StringP("subtype", "s", "", fmt.Sprintf("Integation subtype, integration dependent"))
+	RelayCommand.Flags().StringP("subtype", "s", "", "Integation subtype, integration dependent")
 	RelayCommand.Flags().StringP("alias", "a", "", "The alias to use for the integration")
 	RelayCommand.MarkFlagRequired("integration")
 	RelayCommand.MarkFlagRequired("alias")

--- a/agent/cmd/serve.go
+++ b/agent/cmd/serve.go
@@ -55,14 +55,16 @@ func buildServeStack(cmd *cobra.Command, cfg config.AgentConfig) fx.Option {
 			Integration: common.IntegrationCustom,
 			Alias:       cfg.IntegrationAlias,
 		}),
+		fx.Provide(createHttpServer),
 		fx.Provide(cron.New),
-		fx.Invoke(createHttpServer),
 		fx.Invoke(createWebhookHttpServer),
 	}
 
 	if !cfg.DryRun || os.Getenv("BROKER_TOKEN") != "" {
 		// we only start the broker if we have a token
-		opts = append(opts, fx.Invoke(snykbroker.NewRelayInstanceManager))
+		opts = append(opts,
+			fx.Invoke(snykbroker.NewRelayInstanceManager),
+		)
 	}
 
 	return fx.Options(

--- a/agent/cmd/serve_test.go
+++ b/agent/cmd/serve_test.go
@@ -32,6 +32,25 @@ func TestBuildServeStack(t *testing.T) {
 	app.Stop(context.Background())
 }
 
+func TestBuildServeStackLive(t *testing.T) {
+
+	os.Setenv("CORTEX_API_TOKEN", "xxxyyyzzz")
+	os.Setenv("PORT", "0")
+	config := config.NewAgentEnvConfig()
+	config.HttpServerPort = 0
+	stack := buildServeStack(&cobra.Command{}, config)
+
+	require.NotNil(t, stack)
+
+	app := fx.New(
+		stack,
+	)
+
+	err := app.Start(context.Background())
+	require.NoError(t, err)
+	app.Stop(context.Background())
+}
+
 func TestBuildRelayStack(t *testing.T) {
 
 	envVars := map[string]string{

--- a/agent/common/integration.go
+++ b/agent/common/integration.go
@@ -16,7 +16,7 @@ type Integration string
 
 const (
 	// NOTE: these MUST match up with values from the server side enum
-	IntegrationCustom    Integration = "cortexcustomer"
+	IntegrationCustom    Integration = ""
 	IntegrationGithub    Integration = "github"
 	IntegrationSlack     Integration = "slack"
 	IntegrationJira      Integration = "jira"

--- a/agent/server/http/axon_handler.go
+++ b/agent/server/http/axon_handler.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const axonPathRoot = "/__axon"
+const AxonPathRoot = "/__axon"
 
 type axonHandler struct {
 	io.Closer
@@ -47,10 +47,10 @@ func (h *axonHandler) grpcClient() (pb.AxonAgentClient, error) {
 }
 
 func (h *axonHandler) RegisterRoutes(mux *http.ServeMux) error {
-	mux.HandleFunc(axonPathRoot+"/healthcheck", h.healthcheck)
-	mux.HandleFunc(axonPathRoot+"/info", h.info)
-	mux.HandleFunc(axonPathRoot+"/handlers", h.listHandlers)
-	mux.HandleFunc(axonPathRoot+"/handlers/{handler}", h.getHandler)
+	mux.HandleFunc(AxonPathRoot+"/healthcheck", h.healthcheck)
+	mux.HandleFunc(AxonPathRoot+"/info", h.info)
+	mux.HandleFunc(AxonPathRoot+"/handlers", h.listHandlers)
+	mux.HandleFunc(AxonPathRoot+"/handlers/{handler}", h.getHandler)
 	// TODO: handler logs, etc
 	return nil
 }

--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -50,7 +50,11 @@ type inflightRequest struct {
 	sentAt time.Time
 }
 
-func NewAxonAgent(logger *zap.Logger, config config.AgentConfig, manager handler.Manager) *AxonAgent {
+func NewAxonAgent(
+	logger *zap.Logger,
+	config config.AgentConfig,
+	manager handler.Manager,
+) *AxonAgent {
 	logger = logger.Named("axon-server")
 	agent := &AxonAgent{
 		config:              config,

--- a/agent/server/snykbroker/relay_instance_manager.go
+++ b/agent/server/snykbroker/relay_instance_manager.go
@@ -63,7 +63,7 @@ func NewRelayInstanceManager(
 }
 
 func (r *relayInstanceManager) RegisterRoutes(mux *http.ServeMux) error {
-	mux.Handle("__axon/reregister", r)
+	mux.Handle(fmt.Sprintf("%s/reregister", cortexHttp.AxonPathRoot), r)
 	return nil
 }
 

--- a/docker/app_entrypoint.sh
+++ b/docker/app_entrypoint.sh
@@ -6,7 +6,7 @@ shift 1
 touch /tmp/app.log
 touch /tmp/agent.log
 tail -f /tmp/app.log -f /tmp/agent.log  &
-
+export AXON_APP=1
 run_agent() {
     echo "Starting Cortex Axon Agent"
     while true;

--- a/docker/start
+++ b/docker/start
@@ -2,6 +2,14 @@
 
 echo "Starting Cortex Axon Agent"
 
+if [ -z "$AXON_APP" ] && [ -n "$KUBERNETES_SERVICE_HOST" ]
+then
+  echo "WARNING: Running agent in 'serve' mode in Kubernetes is unusual."
+  echo "         Typically, the agent run automatically by a packaged Axon app build into a Dockerfile."
+  echo "         See documentation for more information: https://github.com/cortexapps/axon/blob/main/README.md#publishing-your-code"
+  exit 1
+fi
+
 # We write a host entry "cortex-api" for convenience
 if ! grep -q "cortex-api" /etc/hosts >/dev/null; then
     echo "127.0.0.1  cortex-api" >> /etc/hosts


### PR DESCRIPTION
Martin noticed that if you run the server w/o any args as `cortex-axon-agent:latest` in k8s it exits with no errors.

This was actually several problems:

1. There was a bug preventing the DI stack from being built correctly
2. Without `-v` it didn't print the problem
3. No way to let users know that running the agent directly in k8s for `serve` is not the expected patterns

This PR:

- Fixes 1 & 2
- Adds a banner that highlights this is unexpected

```
WARNING: Running agent in 'serve' mode in Kubernetes is unusual.
         Typically, the agent run automatically by a packaged Axon app build into a Dockerfile.
         See documentation for more information: https://github.com/cortexapps/axon/blob/main/README.md#publishing-your-code

```