### PR TITLE
Streaming output error

### DIFF
--- a/agent/server/snykbroker/supervisor.go
+++ b/agent/server/snykbroker/supervisor.go
@@ -256,7 +256,7 @@ func (b *Supervisor) scanLines(reader io.Reader, output chan string, refCount *s
 	// increase buffer size from default of 60K to 1MB
 	buffer := make([]byte, 1024*1024)
 	go func() {
-		for {
+		for !done {
 			scanner := bufio.NewScanner(reader)
 			scanner.Buffer(buffer, cap(buffer)-1)
 			for scanner.Scan() {


### PR DESCRIPTION
Seeing errors like this in agent logs:

```
axon-github-1  | Error reading from scanner: bufio.Scanner: token too long
```

This comes from the scanner that synchronizes multiple error streams (agent, broker, etc) because on of the rows is larger than the 60K default limit (due to DEBUG mode).  

This PR:
* Handles up to 1MB
* Doesn't quit logging if it gets one bigger