### PR TITLE
Simplify supervisor, support agent-triggered broker restart

### DIFF
--- a/agent/cmd/relay.go
+++ b/agent/cmd/relay.go
@@ -66,7 +66,7 @@ var RelayCommand = &cobra.Command{
 		}
 
 		fmt.Println("Starting agent")
-		startAgent(cmd, buildRelayStack(cmd, config, info))
+		startAgent(buildRelayStack(cmd, config, info))
 	},
 }
 

--- a/agent/cmd/serve.go
+++ b/agent/cmd/serve.go
@@ -35,7 +35,7 @@ var serveCmd = &cobra.Command{
 		}
 
 		config.Print()
-		startAgent(cmd, buildServeStack(cmd, config))
+		startAgent(buildServeStack(cmd, config))
 		fmt.Println("Server stopped")
 	},
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -28,6 +28,7 @@ type AgentConfig struct {
 	WebhookServerPort int
 	EnableApiProxy    bool
 	FailWaitTime      time.Duration
+	VerboseOutput     bool
 }
 
 func (ac AgentConfig) Print() {

--- a/agent/server/snykbroker/supervisor_test.go
+++ b/agent/server/snykbroker/supervisor_test.go
@@ -27,6 +27,32 @@ func TestStart_SuccessExit(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestStart_Restart(t *testing.T) {
+
+	supervisor := NewSupervisor(
+		"bash",
+		[]string{"-c", "sleep 300"},
+		map[string]string{
+			"BROKER_TOKEN":      "test_token",
+			"BROKER_SERVER_URL": "http://example.com",
+		},
+		time.Millisecond*10,
+	)
+	output := bytes.Buffer{}
+	supervisor.output = &output
+
+	err := supervisor.Start(1, 1)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, supervisor.Pid())
+	err = supervisor.Close()
+	require.NoError(t, err)
+	require.Equal(t, 0, supervisor.Pid())
+
+	err = supervisor.Start(1, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already started")
+}
+
 func TestStart_FastFail(t *testing.T) {
 
 	// test that if the command fails quickly off the bat, we don't retry anymore


### PR DESCRIPTION
# Background

We might have situations where it is necessary to restart agents in the wild in response to changes on the cortex broker side.

This change improves an existing `reregister` endpoint to be `POST __axon/broker/restart` which triggers a shutdown and restart of the broker, including registration.

In doing this, it was clear the supervisor was overcomplicated so most of this change  is cleaning that up and adding tests for the restart case.