### PR TITLE
Fix prometheus, improve docs, make args consistent

### DIFF
--- a/README.relay.md
+++ b/README.relay.md
@@ -36,8 +36,8 @@ services:
     image: ghcr.io/cortexapps/cortex-axon-agent:latest
     env_file: .env
     env:
-      - GITHUB_API=api.github.com
-      - GITHUB_GRAPHQL=api.github.com
+      - GITHUB_API_ROOT=api.github.com
+      - GITHUB_GRAPHQL_ROOT=api.github.com
     command: [
       "relay",
       "-i", "github",
@@ -51,14 +51,34 @@ services:
 Note if you are using a private Github App installation (subtype `app`), you'll need to set the `GITHUB_API` and `GITHUB_GRAPHQL` to your internal Github API endpoints, for example:
 
 ```
-GITHUB_API=github.mycompany.com/api/v3
-GITHUB_GRAPHQL=github.mycompany.com/api/graphql
+GITHUB_API=https://github.mycompany.com/api/v3
+GITHUB_GRAPHQL=https://github.mycompany.com/api/graphql
 ```
 
 Now run `docker compose up` and you should see the agent start up and connect to Cortex, and be ready to handle traffic.
 
 To test it, go to the settings page for your integration and push "Test Configurations". If you watch the logging output you should see the agent receive the request and forward it to your internal service, and the Cortex Integrations Settings page will show success.
 
+You can see the list of built in file types [here](agent/server/snykbroker/accept_files), which will show the variables needed to execute. If an environment variable
+is not found, the start will fail with an error message indicating the missing variable name.
+
+Generally the naming works like:
+
+* `*_API` - the root URL for the API, such as `https://api.github.com`
+* `*_API_ROOT` - just the host and root path for the integration such as `mycompany.github.com/api/v3`
+* `*_HOST` - just the domain name, such as `mycompany.github.com`
+
+
+### Environment Variables Summary
+### Environment Variables Summary
+
+| Integration    | Environment Variables                                                                                               |
+|----------------|---------------------------------------------------------------------------------------------------------------------|
+| **GitHub**     | `GITHUB_API_ROOT=api.github.com`, `GITHUB_GRAPHQL_ROOT=api.github.com/graphql`, `GITHUB_TOKEN`                |
+| **GitHub App** | Arg `-s app`; `GITHUB_API=https://myapp.github.com/api/v3`, `GITHUB_GRAPHQL=https://myapp.github.com/api/graphql`, `GITHUB_TOKEN` |
+| **Prometheus** | `PROMETHEUS_API=http://mycompany.prometheus.internal`, `PROMETHEUS_USERNAME`, `PROMETHEUS_PASSWORD`                 |
+| **Gitlab**     | `GITLAB_API=https://gitlab.com`, `GITLAB_TOKEN`                                                                     |
+| **Sonarqube**  | `SONARQUBE_API=https://sonarqube.mycompany.com`, `SONARQUBE_TOKEN`                                                 |
 ## How it works
 
 Internally, Cortex Axon uses an open-source project published by Snyk called [Snyk Broker](https://docs.snyk.io/enterprise-setup/snyk-broker). 

--- a/agent/cmd/serve_test.go
+++ b/agent/cmd/serve_test.go
@@ -54,15 +54,15 @@ func TestBuildServeStackLive(t *testing.T) {
 func TestBuildRelayStack(t *testing.T) {
 
 	envVars := map[string]string{
-		"DRYRUN":            "true",
-		"PORT":              "0",
-		"BROKER_SERVER_URL": "http://broker.cortex.io",
-		"BROKER_TOKEN":      "abcd1234",
-		"SNYK_BROKER_PATH":  "bash",
-		"ACCEPT_FILE_DIR":   "../server/snykbroker/accept_files",
-		"GITHUB_TOKEN":      "the-token",
-		"GITHUB_API":        "api.github.com",
-		"GITHUB_GRAPHQL":    "api.github.com/graphql",
+		"DRYRUN":              "true",
+		"PORT":                "0",
+		"BROKER_SERVER_URL":   "http://broker.cortex.io",
+		"BROKER_TOKEN":        "abcd1234",
+		"SNYK_BROKER_PATH":    "bash",
+		"ACCEPT_FILE_DIR":     "../server/snykbroker/accept_files",
+		"GITHUB_TOKEN":        "the-token",
+		"GITHUB_API_ROOT":     "api.github.com",
+		"GITHUB_GRAPHQL_ROOT": "api.github.com/graphql",
 	}
 
 	common.ApplyEnv(envVars)

--- a/agent/common/integration.go
+++ b/agent/common/integration.go
@@ -38,12 +38,14 @@ func (i Integration) String() string {
 }
 
 func (i Integration) Validate() error {
-	switch i {
-	case IntegrationGithub, IntegrationSlack, IntegrationJira, IntegrationGitlab, IntegrationAws, IntegrationSonarqube:
-		return nil
-	default:
-		return fmt.Errorf("invalid integration %s", i)
+
+	for _, integration := range ValidIntegrations() {
+		if i == integration {
+			return nil
+		}
 	}
+
+	return fmt.Errorf("invalid integration %s", i)
 }
 
 func ParseIntegration(s string) (Integration, error) {
@@ -55,7 +57,7 @@ func ParseIntegration(s string) (Integration, error) {
 }
 
 func ValidIntegrations() []Integration {
-	return []Integration{IntegrationGithub, IntegrationSlack, IntegrationJira, IntegrationGitlab, IntegrationAws, IntegrationSonarqube}
+	return []Integration{IntegrationGithub, IntegrationSlack, IntegrationJira, IntegrationGitlab, IntegrationAws, IntegrationSonarqube, IntegrationPrometheus}
 }
 
 type IntegrationInfo struct {

--- a/agent/common/integration_test.go
+++ b/agent/common/integration_test.go
@@ -37,8 +37,8 @@ func TestEmptyAcceptFile(t *testing.T) {
 func TestGithubDefaultAcceptFile(t *testing.T) {
 
 	os.Setenv("GITHUB_TOKEN", "the-github-token")
-	os.Setenv("GITHUB_API", "foo.github.com")
-	os.Setenv("GITHUB_GRAPHQL", "foo.github.com/graphql")
+	os.Setenv("GITHUB_API_ROOT", "foo.github.com")
+	os.Setenv("GITHUB_GRAPHQL_ROOT", "foo.github.com/graphql")
 
 	setAcceptFileDir(t)
 
@@ -56,8 +56,8 @@ func TestGithubDefaultAcceptFile(t *testing.T) {
 func TestGithubDefaultAcceptFileSubtypeExists(t *testing.T) {
 
 	os.Setenv("GITHUB_TOKEN", "the-github-token")
-	os.Setenv("GITHUB_API", "foo.github.com")
-	os.Setenv("GITHUB_GRAPHQL", "foo.github.com/graphql")
+	os.Setenv("GITHUB_API", "https://foo.github.com")
+	os.Setenv("GITHUB_GRAPHQL", "https://foo.github.com/graphql")
 
 	setAcceptFileDir(t)
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -60,6 +60,10 @@ func getInstanceId() string {
 		return id
 	}
 
+	if id := os.Getenv("HOSTNAME"); id != "" && id != "localhost" {
+		return id
+	}
+
 	if _, err := os.Stat(instancePath); os.IsNotExist(err) {
 		id := uuid.New().String()
 		err := os.WriteFile(instancePath, []byte(id), 0644)

--- a/agent/server/snykbroker/accept_files/accept.bitbucket.basic.json
+++ b/agent/server/snykbroker/accept_files/accept.bitbucket.basic.json
@@ -3,28 +3,12 @@
     {
       "method": "any",
       "path": "/*",
-      "origin": "https://${BITBUCKET_API}",
+      "origin": "${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
         "username": "${BITBUCKET_USERNAME}",
         "password": "${BITBUCKET_PASSWORD}"
       }
-    },
-    {
-      "method": "any",
-      "path": "/*",
-      "origin": "https://${BITBUCKET_API}",
-      "auth": {
-          "scheme": "bearer",
-          "token": "${BITBUCKET_TOKEN}"
-      }
-    },
-      {
-        "method": "any",
-        "path": "/*",
-        "origin": "https://${TOKEN}@${BITBUCKET_API}"
-      }
-    
-
+    }
   ]
 }

--- a/agent/server/snykbroker/accept_files/accept.bitbucket.json
+++ b/agent/server/snykbroker/accept_files/accept.bitbucket.json
@@ -3,7 +3,7 @@
     {
       "method": "any",
       "path": "/*",
-      "origin": "https://${BITBUCKET_API}",
+      "origin": "${BITBUCKET_API}",
       "auth": {
           "scheme": "bearer",
           "token": "${BITBUCKET_TOKEN}"

--- a/agent/server/snykbroker/accept_files/accept.github.app.json
+++ b/agent/server/snykbroker/accept_files/accept.github.app.json
@@ -3,7 +3,7 @@
       {
         "method": "any",
         "path": "/*",
-        "origin": "https://${GITHUB_API}",
+        "origin": "${GITHUB_API}",
         "auth": {
           "scheme": "bearer",
           "token": "${GITHUB_TOKEN}"
@@ -12,7 +12,7 @@
       {
         "method": "POST",
         "path": "/graphql",
-        "origin": "https://${GITHUB_GRAPHQL}",
+        "origin": "${GITHUB_GRAPHQL}",
         "auth": {
           "scheme": "bearer",
           "token": "${GITHUB_TOKEN}"

--- a/agent/server/snykbroker/accept_files/accept.github.json
+++ b/agent/server/snykbroker/accept_files/accept.github.json
@@ -3,12 +3,12 @@
       {
         "method": "any",
         "path": "/*",
-        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API_ROOT}"
       },
       {
         "method": "POST",
         "path": "/graphql",
-        "origin": "https:/${GITHUB_TOKEN}@${GITHUB_GRAPHQL}"        
+        "origin": "https:/${GITHUB_TOKEN}@${GITHUB_GRAPHQL_ROOT}"        
       }
     ]
 }

--- a/agent/server/snykbroker/accept_files/accept.gitlab.json
+++ b/agent/server/snykbroker/accept_files/accept.gitlab.json
@@ -3,7 +3,7 @@
     {
       "method": "any",
       "path": "/*",
-      "origin": "https://${GITLAB}",
+      "origin": "${GITLAB_API}",
       "auth": {
         "scheme": "bearer",
         "token": "${GITLAB_TOKEN}"

--- a/agent/server/snykbroker/accept_files/accept.jira.bearer.json
+++ b/agent/server/snykbroker/accept_files/accept.jira.bearer.json
@@ -3,7 +3,7 @@
     {
       "method": "any",
       "path": "/*",
-      "origin": "https://${JIRA_API}",
+      "origin": "${JIRA_API}", 
       "auth": {
           "scheme": "bearer",
           "token": "${JIRA_TOKEN}"

--- a/agent/server/snykbroker/accept_files/accept.jira.json
+++ b/agent/server/snykbroker/accept_files/accept.jira.json
@@ -3,7 +3,7 @@
     {
       "method": "any",
       "path": "/*",
-      "origin": "https://${JIRA_API}",
+      "origin": "${JIRA_API}",
       "auth": {
           "scheme": "basic",
           "username": "${JIRA_USERNAME}",

--- a/agent/server/snykbroker/accept_files/accept.prometheus.json
+++ b/agent/server/snykbroker/accept_files/accept.prometheus.json
@@ -3,7 +3,7 @@
     {
       "method": "any",
       "path": "/*",
-      "origin": "https://${PROMETHEUS_API}",
+      "origin": "${PROMETHEUS_API}",
       "auth": {
           "scheme": "basic",
           "username": "${PROMETHEUS_USERNAME}",

--- a/agent/server/snykbroker/accept_files/accept.sonarqube.json
+++ b/agent/server/snykbroker/accept_files/accept.sonarqube.json
@@ -3,7 +3,7 @@
     {
       "method": "any",
       "path": "/*",
-      "origin": "https://${SONAR_HOST}",
+      "origin": "${SONARQUBE_API}",
       "auth": {
         "scheme": "bearer",
         "token": "${SONAR_TOKEN}"

--- a/agent/server/snykbroker/relay_instance_manager.go
+++ b/agent/server/snykbroker/relay_instance_manager.go
@@ -120,6 +120,7 @@ func (r *relayInstanceManager) getUrlAndToken() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+	r.logger.Info("Received registration info", zap.String("serverUri", reg.ServerUri))
 
 	return reg.ServerUri, reg.Token, nil
 }

--- a/agent/server/snykbroker/relay_instance_manager_test.go
+++ b/agent/server/snykbroker/relay_instance_manager_test.go
@@ -70,12 +70,12 @@ func (w *wrappedRelayInstanceManager) Instance() *relayInstanceManager {
 
 func createTestRelayInstanceManager(t *testing.T, controller *gomock.Controller, expectedError error) *wrappedRelayInstanceManager {
 	envVars := map[string]string{
-		"ACCEPT_FILE_DIR":  "./accept_files",
-		"GITHUB_TOKEN":     "the-token",
-		"GITHUB_API":       "api.github.com",
-		"GITHUB_GRAPHQL":   "api.github.com/graphql",
-		"SNYK_BROKER_PATH": "sleep",
-		"SNYK_BROKER_ARGS": "60",
+		"ACCEPT_FILE_DIR":     "./accept_files",
+		"GITHUB_TOKEN":        "the-token",
+		"GITHUB_API_ROOT":     "https://api.github.com",
+		"GITHUB_GRAPHQL_ROOT": "https://api.github.com/graphql",
+		"SNYK_BROKER_PATH":    "sleep",
+		"SNYK_BROKER_ARGS":    "60",
 	}
 
 	common.ApplyEnv(envVars)

--- a/agent/test/filter.schema.json
+++ b/agent/test/filter.schema.json
@@ -21,7 +21,7 @@
             },
             "origin": {
               "type": "string",
-              "pattern": "^http.*$"
+              "pattern": "^.+$"
             },
             "auth": {
               "type": "object",


### PR DESCRIPTION
Doing E2E testing, notice I'd missed adding the `prometheus` type.

This also adds better docs for all integration types and makes the variable naming consistent.