### PR TITLE
Add reregister endpoint

### DIFF
--- a/agent/server/http/axon_handler.go
+++ b/agent/server/http/axon_handler.go
@@ -50,8 +50,7 @@ func (h *axonHandler) RegisterRoutes(mux *http.ServeMux) error {
 	mux.HandleFunc(AxonPathRoot+"/healthcheck", h.healthcheck)
 	mux.HandleFunc(AxonPathRoot+"/info", h.info)
 	mux.HandleFunc(AxonPathRoot+"/handlers", h.listHandlers)
-	mux.HandleFunc(AxonPathRoot+"/handlers/{handler}", h.getHandler)
-	// TODO: handler logs, etc
+	mux.HandleFunc(AxonPathRoot+"/handlers/{handler}", h.getHandler)	
 	return nil
 }
 
@@ -82,7 +81,7 @@ func (h *axonHandler) healthcheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *axonHandler) info(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
+
 	result := &struct {
 		Integration string   `json:"integration"`
 		Alias       string   `json:"alias"`

--- a/agent/server/snykbroker/relay_instance_manager.go
+++ b/agent/server/snykbroker/relay_instance_manager.go
@@ -69,6 +69,11 @@ func (r *relayInstanceManager) RegisterRoutes(mux *http.ServeMux) error {
 	return nil
 }
 
+func (r *relayInstanceManager) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// should never be called, here just to satisfy the interface
+	w.WriteHeader(http.StatusNotFound)
+}
+
 func (r *relayInstanceManager) handleRestart(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)


### PR DESCRIPTION
We need the ability to as an agent to register, for example if redis loses the config, we can ask it to go through the flow so we can securely identify.