### PR TITLE
Fix Python Publishing: Typos and Unique Ids.

### DIFF
--- a/.github/workflows/sdks-python-publish.yml
+++ b/.github/workflows/sdks-python-publish.yml
@@ -45,7 +45,7 @@ jobs:
           cd sdks/python
           make all
           python3 -m pip install --upgrade build --break-system-packages
-          poetry config repositories.pypihttps://upload.pypi.org/legacy/
+          poetry config repositories.pypi https://upload.pypi.org/legacy/
           poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
           poetry version ${{ github.event.inputs.version }}
           python3 -m build -v          

--- a/.github/workflows/sdks-python-publish.yml
+++ b/.github/workflows/sdks-python-publish.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt install -y protobuf-compiler
 
       - name: Publish (Test PyPI)
-        id: publish
+        id: publish-test-pypi
         run: |
           cd sdks/python
           make all
@@ -40,7 +40,7 @@ jobs:
           poetry publish -r test-pypi
 
       - name: Publish (Main PyPI)
-        id: publish
+        id: publish-pypi
         run: |
           cd sdks/python
           make all


### PR DESCRIPTION
My previous PR had a typo and required 2 unique names for the github actions. 