### PR TITLE
Auto reregister agents every 15 minutes

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -15,21 +15,22 @@ const DefaultHttpPort = 80
 const WebhookServerPort = 8081
 
 type AgentConfig struct {
-	GrpcPort          int
-	CortexApiBaseUrl  string
-	CortexApiToken    string
-	DryRun            bool
-	DequeueWaitTime   time.Duration
-	HistoryPath       string
-	InstanceId        string
-	Integration       string
-	IntegrationAlias  string
-	HttpServerPort    int
-	WebhookServerPort int
-	SnykBrokerPort    int
-	EnableApiProxy    bool
-	FailWaitTime      time.Duration
-	VerboseOutput     bool
+	GrpcPort              int
+	CortexApiBaseUrl      string
+	CortexApiToken        string
+	DryRun                bool
+	DequeueWaitTime       time.Duration
+	HistoryPath           string
+	InstanceId            string
+	Integration           string
+	IntegrationAlias      string
+	HttpServerPort        int
+	WebhookServerPort     int
+	SnykBrokerPort        int
+	EnableApiProxy        bool
+	FailWaitTime          time.Duration
+	AutoRegisterFrequency time.Duration
+	VerboseOutput         bool
 }
 
 func (ac AgentConfig) Print() {
@@ -145,20 +146,30 @@ func NewAgentEnvConfig() AgentConfig {
 		token = "dry-run"
 	}
 
+	reregisterFrequency := time.Minute * 15
+	if reregisterFrequencyEnv := os.Getenv("AUTO_REGISTER_FREQUENCY"); reregisterFrequencyEnv != "" {
+		var err error
+		reregisterFrequency, err = time.ParseDuration(reregisterFrequencyEnv)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	cfg := AgentConfig{
-		GrpcPort:          port,
-		CortexApiBaseUrl:  baseUrl,
-		CortexApiToken:    token,
-		DryRun:            dryRun,
-		DequeueWaitTime:   dequeueWaitTime,
-		HistoryPath:       historyPath,
-		InstanceId:        getInstanceId(),
-		IntegrationAlias:  identifier,
-		HttpServerPort:    httpPort,
-		WebhookServerPort: WebhookServerPort,
-		SnykBrokerPort:    snykBrokerPort,
-		EnableApiProxy:    true,
-		FailWaitTime:      time.Second * 2,
+		GrpcPort:              port,
+		CortexApiBaseUrl:      baseUrl,
+		CortexApiToken:        token,
+		DryRun:                dryRun,
+		DequeueWaitTime:       dequeueWaitTime,
+		HistoryPath:           historyPath,
+		InstanceId:            getInstanceId(),
+		IntegrationAlias:      identifier,
+		HttpServerPort:        httpPort,
+		WebhookServerPort:     WebhookServerPort,
+		SnykBrokerPort:        snykBrokerPort,
+		EnableApiProxy:        true,
+		FailWaitTime:          time.Second * 2,
+		AutoRegisterFrequency: reregisterFrequency,
 	}
 	return cfg
 }


### PR DESCRIPTION
If an agent is configured and there is a problem with its configuration, it will start and run with a generated token.  But if that config needs to be recreated, it will hold on to the old token, leading to a need to restart the agent to re-register it.

This change auto-reregisters every 15 minutes to ensure these stay in sync.  If any of the registration info (token, server URI) has changed from the the prior call, it restarts the broker.

This adds durability the overall system.