### PR TITLE
Clean up handler history

### DIFF
--- a/agent/server/handler/history_manager.go
+++ b/agent/server/handler/history_manager.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sort"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	pb "github.com/cortexapps/axon/.generated/proto/github.com/cortexapps/axon"
@@ -18,20 +20,59 @@ import (
 )
 
 type HistoryManager interface {
+	Start() error
+	Close() error
 	Write(ctx context.Context, ex *pb.HandlerExecution) error
 	GetHistory(ctx context.Context, handlerName string, includeLogs bool, tail int32) ([]*pb.HandlerExecution, error)
 }
 
 type historyManager struct {
-	config config.AgentConfig
-	logger *zap.Logger
+	config  config.AgentConfig
+	logger  *zap.Logger
+	running atomic.Bool
+	done    chan struct{}
 }
 
 func NewHistoryManager(config config.AgentConfig, logger *zap.Logger) HistoryManager {
 	return &historyManager{
 		config: config,
 		logger: logger,
+		done:   make(chan struct{}),
 	}
+}
+
+const cleanupInterval = time.Hour
+
+func (s *historyManager) Start() error {
+	if s.running.CompareAndSwap(false, true) {
+		s.logger.Info("history manager started")
+		historyPath, err := s.getHistoryDirectory()
+		if err != nil {
+			s.logger.Error("failed to get history directory", zap.Error(err))
+			return err
+		}
+		maxHistoryAge := s.config.HandlerHistoryMaxAge
+		maxSizeBytes := s.config.HandlerHistoryMaxSizeBytes
+		go func() {
+			for s.running.Load() {
+				select {
+				case <-s.done:
+					return
+				case <-time.After(cleanupInterval):
+					minTimestamp := time.Now().Add(-maxHistoryAge)
+					s.cleanupDirectory(historyPath, minTimestamp, maxSizeBytes, nil)
+				}
+			}
+		}()
+	}
+	return nil
+}
+
+func (s *historyManager) Close() error {
+	if s.running.CompareAndSwap(true, false) {
+		close(s.done)
+	}
+	return nil
 }
 
 var fileParseRegExp = regexp.MustCompile(`^(\d+)-(.+)\.json$`)
@@ -54,20 +95,79 @@ func (s *historyManager) parseHistoryFileName(historyFilePath string) (string, t
 
 }
 
-func (s *historyManager) getHistoryPath(handlerName string, timestamp time.Time) string {
-	if s.config.HistoryPath == "" {
+func (s *historyManager) getHistoryDirectory() (string, error) {
+	if s.config.HandlerHistoryPath == "" {
 		s.logger.Warn("history path not set")
-		return ""
+		return "", nil
 	}
 
-	err := os.MkdirAll(s.config.HistoryPath, 0755)
+	err := os.MkdirAll(s.config.HandlerHistoryPath, 0755)
 	if err != nil {
 		s.logger.Error("failed to create history path", zap.Error(err))
-		return ""
+		return "", err
+	}
+	return s.config.HandlerHistoryPath, nil
+}
+
+func (s *historyManager) getHistoryPath(handlerName string, timestamp time.Time) string {
+
+	return fmt.Sprintf("%s/%d-%s.json", s.config.HandlerHistoryPath, timestamp.UnixMilli(), handlerName)
+}
+
+func (s *historyManager) cleanupDirectory(path string, minTimestamp time.Time, maxSizeBytes int64, extractTimestamp func(info os.FileInfo) time.Time) (int, error) {
+	// Read all files in the directory
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return 0, err
 	}
 
-	return fmt.Sprintf("%s/%d-%s.json", s.config.HistoryPath, timestamp.UnixMilli(), handlerName)
+	infos := make([]os.FileInfo, 0, len(files))
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		info, err := file.Info()
+		if err != nil {
+			s.logger.Error("failed to get file info", zap.String("path", file.Name()), zap.Error(err))
+			continue
+		}
+		infos = append(infos, info)
+	}
 
+	// Sort files by modification time (newest first)
+	sort.Slice(infos, func(i, j int) bool {
+		leftModTime := infos[i].ModTime()
+		rightModTime := infos[j].ModTime()
+		return leftModTime.UnixMilli() > rightModTime.UnixMilli()
+	})
+
+	if extractTimestamp == nil {
+		extractTimestamp = func(info os.FileInfo) time.Time {
+			return info.ModTime()
+		}
+	}
+
+	var deleteCount int
+	var remainingSize int64 = int64(maxSizeBytes)
+	for _, info := range infos {
+		timestamp := extractTimestamp(info)
+		tooOld := timestamp.Before(minTimestamp)
+		if !tooOld {
+			remainingSize -= info.Size()
+		}
+		if tooOld || remainingSize < 0 {
+			filePath := filepath.Join(path, info.Name())
+			err := os.Remove(filePath)
+			if err != nil {
+				s.logger.Error("failed to remove history file", zap.String("path", filePath), zap.Error(err))
+			} else {
+				deleteCount++
+			}
+		}
+	}
+
+	s.logger.Info("cleaned up history directory", zap.String("path", path), zap.Int("deleted_file_count", deleteCount))
+	return deleteCount, nil
 }
 
 // ReportInvocation is called by the client to report the result of an invocation, which will
@@ -93,7 +193,7 @@ func (s *historyManager) Write(ctx context.Context, execution *pb.HandlerExecuti
 // GetHandlerHistory returns the history of a handler
 func (s *historyManager) GetHistory(ctx context.Context, handlerName string, includeLogs bool, tail int32) ([]*pb.HandlerExecution, error) {
 	// search the handler history path for anything with this handler name
-	files, err := os.ReadDir(s.config.HistoryPath)
+	files, err := os.ReadDir(s.config.HandlerHistoryPath)
 
 	if os.IsNotExist(err) {
 		return make([]*pb.HandlerExecution, 0), nil
@@ -116,7 +216,7 @@ func (s *historyManager) GetHistory(ctx context.Context, handlerName string, inc
 		}
 
 		if fileName == handlerName {
-			filePath := filepath.Join(s.config.HistoryPath, file.Name())
+			filePath := filepath.Join(s.config.HandlerHistoryPath, file.Name())
 			contents, err := os.ReadFile(filePath)
 			if err != nil {
 				return nil, err

--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -277,6 +277,11 @@ func (s *AxonAgent) Start(ctx context.Context) error {
 		log.Fatalf("failed to listen: %v", err)
 	}
 
+	err = s.historyManager.Start()
+	if err != nil {
+		log.Fatal("failed to start history manager", zap.Error(err))
+	}
+
 	s.grpcServer = grpc.NewServer()
 	pb.RegisterAxonAgentServer(s.grpcServer, s)
 
@@ -312,6 +317,10 @@ func (s *AxonAgent) Close() {
 	if s.grpcServer != nil {
 		s.grpcServer.Stop()
 		s.grpcServer = nil
+	}
+	if s.historyManager != nil {
+		s.historyManager.Close()
+		s.historyManager = nil
 	}
 	s.Manager.Close()
 }

--- a/agent/server/server_e2e_test.go
+++ b/agent/server/server_e2e_test.go
@@ -28,12 +28,12 @@ func TestGRPCServer_RegisterHandlerAndDispatch(t *testing.T) {
 	}()
 
 	config := config.AgentConfig{
-		GrpcPort:         port,
-		CortexApiBaseUrl: "http://localhost",
-		CortexApiToken:   "test-token",
-		DryRun:           false,
-		DequeueWaitTime:  1 * time.Second,
-		HistoryPath:      historyPath,
+		GrpcPort:           port,
+		CortexApiBaseUrl:   "http://localhost",
+		CortexApiToken:     "test-token",
+		DryRun:             false,
+		DequeueWaitTime:    1 * time.Second,
+		HandlerHistoryPath: historyPath,
 	}
 
 	logger, _ := zap.NewDevelopment()
@@ -127,12 +127,12 @@ func TestGRPCServer_RegisterHandlerAndDispatchInvoke(t *testing.T) {
 	}()
 
 	config := config.AgentConfig{
-		GrpcPort:         port,
-		CortexApiBaseUrl: "http://localhost",
-		CortexApiToken:   "test-token",
-		DryRun:           false,
-		DequeueWaitTime:  1 * time.Second,
-		HistoryPath:      historyPath,
+		GrpcPort:           port,
+		CortexApiBaseUrl:   "http://localhost",
+		CortexApiToken:     "test-token",
+		DryRun:             false,
+		DequeueWaitTime:    1 * time.Second,
+		HandlerHistoryPath: historyPath,
 	}
 
 	logger, _ := zap.NewDevelopment()
@@ -238,12 +238,12 @@ func TestGRPCServer_ClientAutoClose(t *testing.T) {
 	}()
 
 	config := config.AgentConfig{
-		GrpcPort:         port,
-		CortexApiBaseUrl: "http://localhost",
-		CortexApiToken:   "test-token",
-		DryRun:           false,
-		DequeueWaitTime:  100 * time.Millisecond,
-		HistoryPath:      historyPath,
+		GrpcPort:           port,
+		CortexApiBaseUrl:   "http://localhost",
+		CortexApiToken:     "test-token",
+		DryRun:             false,
+		DequeueWaitTime:    100 * time.Millisecond,
+		HandlerHistoryPath: historyPath,
 	}
 
 	logger, _ := zap.NewDevelopment()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ COPY docker/app_entrypoint.sh /app/app_entrypoint.sh
 
 
 ENV CORTEX_API_BASE_URL=https://api.getcortexapp.com
-ENV HISTORY_PATH=/agent/history
+ENV HANDLER_HISTORY_PATH=/var/log/axon/history
 
 EXPOSE 50051
 


### PR DESCRIPTION
Ensure handler history doesn't get to big, can be set with `HANDLER_HISTORY_MAX_AGE=7d` or `HANDLER_HISTORY_MAX_SIZE=bytes`