### PR TITLE
Add relay local proxy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -91,6 +91,7 @@
                 "PORT" : "7399",
                 "GITHUB_API": "api.github.com",
                 "GITHUB_GRAPHQL": "api.github.com/graphql",
+                "ENABLE_RELAY_REFLECTOR": "false"
             }        
         },
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -91,7 +91,7 @@
                 "PORT" : "7399",
                 "GITHUB_API": "api.github.com",
                 "GITHUB_GRAPHQL": "api.github.com/graphql",
-                "ENABLE_RELAY_REFLECTOR": "false"
+                "ENABLE_RELAY_REFLECTOR": "true"
             }        
         },
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -35,8 +35,9 @@ type AgentConfig struct {
 	HandlerHistoryMaxAge       time.Duration
 	HandlerHistoryMaxSizeBytes int64
 
-	HttpDisableTLS     bool
-	HttpCaCertFilePath string
+	HttpDisableTLS           bool
+	HttpCaCertFilePath       string
+	EnableHttpRelayReflector bool
 }
 
 func (ac AgentConfig) Print() {
@@ -205,6 +206,10 @@ func NewAgentEnvConfig() AgentConfig {
 	if caCertFilePath := os.Getenv("CA_CERT_PATH"); caCertFilePath != "" {
 		cfg.HttpCaCertFilePath = caCertFilePath
 		cfg.HttpCaCertFilePath = filepath.Clean(cfg.HttpCaCertFilePath)
+	}
+
+	if relayReflector := os.Getenv("ENABLE_RELAY_REFLECTOR"); relayReflector == "true" {
+		cfg.EnableHttpRelayReflector = true
 	}
 
 	return cfg

--- a/agent/server/http/http_server.go
+++ b/agent/server/http/http_server.go
@@ -22,6 +22,7 @@ type Server interface {
 	io.Closer
 	RegisterHandler(h RegisterableHandler)
 	Start() (int, error)
+	Port() int
 }
 
 type RegisterableHandler interface {
@@ -217,6 +218,13 @@ func (h *httpServer) Start() (int, error) {
 	h.listener = ln
 	h.port = ln.Addr().(*net.TCPAddr).Port
 	return h.port, nil
+}
+
+func (h *httpServer) Port() int {
+	if h.port == 0 {
+		panic("Port called before Start")
+	}
+	return h.port
 }
 
 func (h *httpServer) Close() error {

--- a/agent/server/snykbroker/module.go
+++ b/agent/server/snykbroker/module.go
@@ -1,10 +1,24 @@
 package snykbroker
 
 import (
+	"net/http"
+
+	"github.com/cortexapps/axon/config"
 	"go.uber.org/fx"
+	"go.uber.org/zap"
 )
 
 var Module = fx.Module("snykbroker",
 	fx.Provide(NewRegistration),
+	fx.Provide(MaybeNewRegistrationReflector),
 	fx.Invoke(NewRelayInstanceManager),
 )
+
+func MaybeNewRegistrationReflector(lifecycle fx.Lifecycle, config config.AgentConfig, logger *zap.Logger, transport *http.Transport) *RegistrationReflector {
+
+	if !config.EnableHttpRelayReflector {
+		return nil
+	}
+
+	return NewRegistrationReflector(lifecycle, logger, transport)
+}

--- a/agent/server/snykbroker/reflector.go
+++ b/agent/server/snykbroker/reflector.go
@@ -1,0 +1,136 @@
+package snykbroker
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sync/atomic"
+
+	cortexHttp "github.com/cortexapps/axon/server/http"
+	"github.com/gorilla/mux"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+)
+
+type RegistrationReflector struct {
+	logger        *zap.Logger
+	transport     *http.Transport
+	server        cortexHttp.Server
+	proxyHandler  http.Handler
+	targetURI     string
+	serverStarted atomic.Bool
+}
+
+func NewRegistrationReflector(lifecycle fx.Lifecycle, logger *zap.Logger, transport *http.Transport) *RegistrationReflector {
+
+	httpParams := cortexHttp.HttpServerParams{
+		Logger: logger.Named("relay-reflector"),
+	}
+
+	server := cortexHttp.NewHttpServer(httpParams, cortexHttp.WithName("relay-reflector"))
+
+	rr := &RegistrationReflector{
+		transport: transport,
+		server:    server,
+		logger:    httpParams.Logger,
+	}
+
+	server.RegisterHandler(rr)
+
+	if lifecycle != nil {
+		lifecycle.Append(
+			fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					_, err := rr.Start()
+					return err
+				},
+			},
+		)
+	}
+
+	return rr
+}
+
+func (rr *RegistrationReflector) Start() (int, error) {
+
+	if rr.serverStarted.CompareAndSwap(false, true) {
+		_, err := rr.server.Start()
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return rr.server.Port(), nil
+}
+
+func (rr *RegistrationReflector) Stop() error {
+	if rr.server != nil {
+		return rr.server.Close()
+	}
+	return nil
+}
+
+func (rr *RegistrationReflector) SetTargetURI(targetURI string) error {
+	if targetURI == "" {
+		return fmt.Errorf("target URI cannot be empty")
+	}
+
+	if rr.targetURI == targetURI {
+		return nil
+	}
+
+	if rr.targetURI != "" {
+		rr.proxyHandler = nil
+	}
+
+	rr.targetURI = targetURI
+
+	asUri, err := url.Parse(targetURI)
+	if err != nil {
+		return fmt.Errorf("invalid target URI: %w", err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(asUri)
+
+	// The proxy needs to override the Host and the URL host to not get erroneous 404s
+	// https://stackoverflow.com/questions/23164547/golang-reverseproxy-not-working
+	// https://github.com/golang/go/issues/14413
+	defaultDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		defaultDirector(req)
+		req.Host = asUri.Host
+	}
+
+	if rr.transport != nil {
+		proxy.Transport = rr.transport
+	}
+	rr.proxyHandler = proxy
+	rr.logger.Info("Reflecting broker calls",
+		zap.String("targetURI", targetURI),
+		zap.String("proxyURI", fmt.Sprintf("http://localhost:%d", rr.server.Port())))
+	return nil
+}
+
+func (rr *RegistrationReflector) Target() string {
+	return rr.targetURI
+}
+
+func (rr *RegistrationReflector) ProxyURI() string {
+	_, err := rr.Start()
+	if err != nil {
+		panic(fmt.Sprintf("failed to start registration reflector: %v", err))
+	}
+	return fmt.Sprintf("http://localhost:%d", rr.server.Port())
+}
+func (rr *RegistrationReflector) RegisterRoutes(mux *mux.Router) error {
+	mux.PathPrefix("/").Handler(rr)
+	return nil
+}
+
+func (rr *RegistrationReflector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	// Serve the request using the proxy handler
+	rr.proxyHandler.ServeHTTP(w, r)
+}

--- a/agent/server/snykbroker/relay_instance_manager.go
+++ b/agent/server/snykbroker/relay_instance_manager.go
@@ -40,6 +40,9 @@ type relayInstanceManager struct {
 	startCount        atomic.Int32
 	tokenInfo         *tokenInfo
 	operationsCounter *prometheus.CounterVec
+	transport         *http.Transport
+
+	reflector *RegistrationReflector
 }
 
 type tokenInfo struct {
@@ -69,7 +72,9 @@ type RelayInstanceManagerParams struct {
 	IntegrationInfo common.IntegrationInfo
 	HttpServer      cortexHttp.Server
 	Registration    Registration
-	Registry        *prometheus.Registry `optional:"true"`
+	Transport       *http.Transport        `optional:"true"`
+	Registry        *prometheus.Registry   `optional:"true"`
+	Reflector       *RegistrationReflector `optional:"true"`
 }
 
 func NewRelayInstanceManager(
@@ -87,6 +92,7 @@ func NewRelayInstanceManager(
 			},
 			[]string{"integration", "alias", "operation", "status"},
 		),
+		transport: p.Transport,
 	}
 
 	p.HttpServer.RegisterHandler(mgr)
@@ -94,6 +100,8 @@ func NewRelayInstanceManager(
 	if p.Registry != nil {
 		p.Registry.MustRegister(mgr.operationsCounter)
 	}
+
+	mgr.reflector = p.Reflector
 
 	if p.Lifecycle != nil {
 		p.Lifecycle.Append(fx.Hook{
@@ -240,6 +248,11 @@ func (r *relayInstanceManager) getUrlAndToken() (*tokenInfo, error) {
 		r.logger.Info("Registration info has changed", zap.String("uri", tokenInfo.ServerUri), zap.String("token", tokenInfo.Token))
 		tokenInfo.HasChanged = true
 		r.tokenInfo = tokenInfo
+	}
+
+	if r.reflector != nil {
+		r.reflector.SetTargetURI(tokenInfo.ServerUri)
+		tokenInfo.ServerUri = r.reflector.ProxyURI()
 	}
 
 	return tokenInfo, nil
@@ -439,6 +452,11 @@ func (r *relayInstanceManager) Start() error {
 }
 
 func (r *relayInstanceManager) setHttpProxyEnvVars(brokerEnv map[string]string) {
+
+	if r.config.EnableHttpRelayReflector {
+		r.logger.Info("HTTP Relay Reflector is enabled, not setting HTTP_PROXY environment variables")
+		return
+	}
 
 	httpProxy := os.Getenv("HTTP_PROXY")
 	if httpProxy != "" && brokerEnv["HTTP_PROXY"] == "" {

--- a/agent/server/snykbroker/relay_instance_manager.go
+++ b/agent/server/snykbroker/relay_instance_manager.go
@@ -453,11 +453,6 @@ func (r *relayInstanceManager) Start() error {
 
 func (r *relayInstanceManager) setHttpProxyEnvVars(brokerEnv map[string]string) {
 
-	if r.config.EnableHttpRelayReflector {
-		r.logger.Info("HTTP Relay Reflector is enabled, not setting HTTP_PROXY environment variables")
-		return
-	}
-
 	httpProxy := os.Getenv("HTTP_PROXY")
 	if httpProxy != "" && brokerEnv["HTTP_PROXY"] == "" {
 		brokerEnv["HTTP_PROXY"] = httpProxy
@@ -473,6 +468,10 @@ func (r *relayInstanceManager) setHttpProxyEnvVars(brokerEnv map[string]string) 
 
 	if certPath := r.getCertFilePath(r.config.HttpCaCertFilePath); certPath != "" {
 		brokerEnv["NODE_EXTRA_CA_CERTS"] = certPath
+	}
+
+	if r.config.HttpDisableTLS {
+		brokerEnv["NODE_TLS_REJECT_UNAUTHORIZED"] = "0"
 	}
 }
 


### PR DESCRIPTION
We are seeing problems with Node (Snyk Broker) dealing with certificates.

As a workaround, this redirects all broker traffic back through the agent which then forwards it out to the `BROKER_SERVER_URI` through Go, which respects system and extra certificates properly.