### PR TITLE
WIP: all traffic through reflector

### DIFF
--- a/agent/cmd/relay.go
+++ b/agent/cmd/relay.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cortexapps/axon/common"
 	"github.com/cortexapps/axon/config"
-	"github.com/cortexapps/axon/server/http"
+	"github.com/cortexapps/axon/server/handler"
 	"github.com/cortexapps/axon/server/snykbroker"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -84,7 +84,7 @@ func buildRelayStack(cmd *cobra.Command, cfg config.AgentConfig, integrationInfo
 	stack := fx.Options(
 		initStack(cmd, cfg, integrationInfo),
 		AgentModule,
-		http.Module,
+		fx.Provide(handler.NewHandlerManager),
 		snykbroker.Module,
 	)
 	return stack

--- a/agent/cmd/serve_test.go
+++ b/agent/cmd/serve_test.go
@@ -39,6 +39,7 @@ func TestBuildServeStack(t *testing.T) {
 	os.Setenv("PORT", "0")
 	config := config.NewAgentEnvConfig()
 	config.HttpServerPort = 0
+	config.WebhookServerPort = 0
 	stack := buildServeStack(&cobra.Command{}, config)
 
 	require.NotNil(t, stack)
@@ -142,6 +143,7 @@ func TestBuildRelayStack(t *testing.T) {
 	config := config.NewAgentEnvConfig()
 	config.FailWaitTime = time.Millisecond
 	config.HttpServerPort = getRandomPort()
+	config.WebhookServerPort = getRandomPort()
 	// Set a random port for the HTTP server
 	stack := buildRelayStack(&cobra.Command{}, config, common.IntegrationInfo{
 		Integration: common.IntegrationGithub,

--- a/agent/common/integration_test.go
+++ b/agent/common/integration_test.go
@@ -162,6 +162,67 @@ func TestLoadIntegrationAcceptFilePoolVars(t *testing.T) {
 	require.NotContains(t, string(contents), "GITHUB_TOKEN_POOL")
 }
 
+func TestAcceptRewrite(t *testing.T) {
+	acceptFileContents := `
+	{
+		"public": [
+		{
+			"method": "any",
+			"path": "/*"
+		}
+		],
+		"private": [
+		{
+			"method": "any",
+			"path": "/*",
+			"origin": "http://python-server"
+		}
+		]
+	}	
+	`
+	acceptFilePath := writeTempFile(t, acceptFileContents)
+	info := IntegrationInfo{
+		Integration:    IntegrationGithub,
+		AcceptFilePath: acceptFilePath,
+	}
+	rewritten, err := info.RewriteOrigins(acceptFilePath, func(origin string) string {
+		if origin == "http://python-server" {
+			return "http://new-python-server"
+		}
+		return origin
+	})
+	require.NoError(t, err)
+	contents, err := os.ReadFile(rewritten)
+	require.NoError(t, err)
+	require.Equal(t, `{"private":[{"method":"any","origin":"http://new-python-server","path":"/*"}],"public":[{"method":"any","path":"/*"}]}`, string(contents))
+}
+
+func TestGetOrigin(t *testing.T) {
+
+	os.Setenv("USER", "testuser")
+	os.Setenv("API", "api.example.com")
+
+	cases :=
+		[]struct {
+			input    string
+			expected string
+		}{
+			{"http://example.com", "http://example.com"},
+			{"https://${USER}@example.com", "https://testuser@example.com"},
+			{"http://${USER}@${API}/path", "http://testuser@api.example.com/path"},
+		}
+
+	ii := IntegrationInfo{}
+
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			origin := ii.getOrigin(c.input)
+			require.Equal(t, c.expected, origin)
+		})
+	}
+
+}
+
 func TestLoadValidationParams(t *testing.T) {
 	ii := IntegrationInfo{
 		Integration: IntegrationGithub,

--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -86,11 +86,20 @@ func NewAxonAgent(
 }
 
 func (s *AxonAgent) RegisterHandler(ctx context.Context, req *pb.RegisterHandlerRequest) (*pb.RegisterHandlerResponse, error) {
+
+	if s.Manager == nil {
+		return nil, fmt.Errorf("handler manager is not initialized")
+	}
+
 	id, err := s.Manager.RegisterHandler(req.DispatchId, req.HandlerName, time.Duration(req.TimeoutMs)*time.Millisecond, req.Options...)
 	return &pb.RegisterHandlerResponse{Id: id}, err
 }
 
 func (s *AxonAgent) UnregisterHandler(ctx context.Context, req *pb.UnregisterHandlerRequest) (*pb.UnregisterHandlerResponse, error) {
+	if s.Manager == nil {
+		return nil, fmt.Errorf("handler manager is not initialized")
+	}
+
 	s.Manager.UnregisterHandler(req.Id)
 	return &pb.UnregisterHandlerResponse{}, nil
 }
@@ -101,6 +110,10 @@ func (s *AxonAgent) UnregisterHandler(ctx context.Context, req *pb.UnregisterHan
 // agent.  When a DispatchResponse is received, the client should call its method then
 // ReportInvocation to report the result of the invocation.
 func (s *AxonAgent) Dispatch(stream pb.AxonAgent_DispatchServer) error {
+
+	if s.Manager == nil {
+		return fmt.Errorf("handler manager is not initialized")
+	}
 
 	firstRequest := true
 	for {
@@ -248,6 +261,11 @@ func (s *AxonAgent) ReportInvocation(ctx context.Context, req *pb.ReportInvocati
 
 // ListHandlers returns a list of all registered handlers
 func (s *AxonAgent) ListHandlers(ctx context.Context, req *pb.ListHandlersRequest) (*pb.ListHandlersResponse, error) {
+
+	if s.Manager == nil {
+		return &pb.ListHandlersResponse{}, nil
+	}
+
 	handlers := s.Manager.ListHandlers()
 	resp := &pb.ListHandlersResponse{
 		Handlers: make([]*pb.HandlerInfo, 0),

--- a/agent/server/snykbroker/module.go
+++ b/agent/server/snykbroker/module.go
@@ -1,11 +1,8 @@
 package snykbroker
 
 import (
-	"net/http"
-
 	"github.com/cortexapps/axon/config"
 	"go.uber.org/fx"
-	"go.uber.org/zap"
 )
 
 var Module = fx.Module("snykbroker",
@@ -14,11 +11,11 @@ var Module = fx.Module("snykbroker",
 	fx.Invoke(NewRelayInstanceManager),
 )
 
-func MaybeNewRegistrationReflector(lifecycle fx.Lifecycle, config config.AgentConfig, logger *zap.Logger, transport *http.Transport) *RegistrationReflector {
+func MaybeNewRegistrationReflector(config config.AgentConfig, p RegistrationReflectorParams) *RegistrationReflector {
 
 	if !config.EnableHttpRelayReflector {
 		return nil
 	}
 
-	return NewRegistrationReflector(lifecycle, logger, transport)
+	return NewRegistrationReflector(p)
 }

--- a/agent/server/snykbroker/reflector.go
+++ b/agent/server/snykbroker/reflector.go
@@ -3,13 +3,17 @@ package snykbroker
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
+	"strings"
 	"sync/atomic"
 
 	cortexHttp "github.com/cortexapps/axon/server/http"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )
@@ -18,29 +22,49 @@ type RegistrationReflector struct {
 	logger        *zap.Logger
 	transport     *http.Transport
 	server        cortexHttp.Server
-	proxyHandler  http.Handler
-	targetURI     string
+	targets       map[string]proxyEntry
 	serverStarted atomic.Bool
 }
 
-func NewRegistrationReflector(lifecycle fx.Lifecycle, logger *zap.Logger, transport *http.Transport) *RegistrationReflector {
+type proxyEntry struct {
+	isDefault bool
+	targetURI string
+	hashCode  string
+	proxyURI  string
+	handler   http.Handler
+}
+
+type RegistrationReflectorParams struct {
+	fx.In
+	Lifecycle fx.Lifecycle `optional:"true"`
+	Logger    *zap.Logger
+	Transport *http.Transport      `optional:"true"`
+	Registry  *prometheus.Registry `optional:"true"`
+}
+
+func NewRegistrationReflector(p RegistrationReflectorParams) *RegistrationReflector {
 
 	httpParams := cortexHttp.HttpServerParams{
-		Logger: logger.Named("relay-reflector"),
+		Logger: p.Logger.Named("relay-reflector"),
+	}
+
+	if p.Registry != nil {
+		httpParams.Registry = p.Registry
 	}
 
 	server := cortexHttp.NewHttpServer(httpParams, cortexHttp.WithName("relay-reflector"))
 
 	rr := &RegistrationReflector{
-		transport: transport,
+		transport: p.Transport,
 		server:    server,
 		logger:    httpParams.Logger,
+		targets:   make(map[string]proxyEntry),
 	}
 
 	server.RegisterHandler(rr)
 
-	if lifecycle != nil {
-		lifecycle.Append(
+	if p.Lifecycle != nil {
+		p.Lifecycle.Append(
 			fx.Hook{
 				OnStart: func(ctx context.Context) error {
 					_, err := rr.Start()
@@ -72,57 +96,120 @@ func (rr *RegistrationReflector) Stop() error {
 	return nil
 }
 
-func (rr *RegistrationReflector) SetTargetURI(targetURI string) error {
+func (rr *RegistrationReflector) getProxy(targetURI string, isDefault bool) (*proxyEntry, error) {
 	if targetURI == "" {
-		return fmt.Errorf("target URI cannot be empty")
+		return nil, fmt.Errorf("target URI cannot be empty")
 	}
 
-	if rr.targetURI == targetURI {
-		return nil
+	key := targetURI
+
+	if isDefault {
+		key = "default"
 	}
 
-	if rr.targetURI != "" {
-		rr.proxyHandler = nil
+	entry, exists := rr.targets[key]
+	if !exists {
+
+		_, err := rr.Start()
+		if err != nil {
+			panic(fmt.Sprintf("failed to start registration reflector: %v", err))
+		}
+
+		asUri, err := url.Parse(targetURI)
+		if err != nil {
+			return nil, fmt.Errorf("invalid target URI: %w", err)
+		}
+
+		proxy := httputil.NewSingleHostReverseProxy(asUri)
+
+		// The proxy needs to override the Host and the URL host to not get erroneous 404s
+		// https://stackoverflow.com/questions/23164547/golang-reverseproxy-not-working
+		// https://github.com/golang/go/issues/14413
+		defaultDirector := proxy.Director
+		proxy.Director = func(req *http.Request) {
+			defaultDirector(req)
+			req.Host = asUri.Host
+		}
+
+		if rr.transport != nil {
+			proxy.Transport = rr.transport
+		}
+		entry = proxyEntry{
+			isDefault: isDefault,
+			targetURI: targetURI,
+			proxyURI:  rr.encodeProxyUri(targetURI),
+			handler:   proxy,
+			hashCode:  strconv.Itoa(int(hashString(targetURI))),
+		}
+		rr.targets[key] = entry
+
+		rr.logger.Info("Registered redirector",
+			zap.String("targetURI", entry.targetURI),
+			zap.String("proxyURI", entry.proxyURI),
+		)
 	}
-
-	rr.targetURI = targetURI
-
-	asUri, err := url.Parse(targetURI)
-	if err != nil {
-		return fmt.Errorf("invalid target URI: %w", err)
-	}
-
-	proxy := httputil.NewSingleHostReverseProxy(asUri)
-
-	// The proxy needs to override the Host and the URL host to not get erroneous 404s
-	// https://stackoverflow.com/questions/23164547/golang-reverseproxy-not-working
-	// https://github.com/golang/go/issues/14413
-	defaultDirector := proxy.Director
-	proxy.Director = func(req *http.Request) {
-		defaultDirector(req)
-		req.Host = asUri.Host
-	}
-
-	if rr.transport != nil {
-		proxy.Transport = rr.transport
-	}
-	rr.proxyHandler = proxy
-	rr.logger.Info("Reflecting broker calls",
-		zap.String("targetURI", targetURI),
-		zap.String("proxyURI", fmt.Sprintf("http://localhost:%d", rr.server.Port())))
-	return nil
+	return &entry, nil
 }
 
-func (rr *RegistrationReflector) Target() string {
-	return rr.targetURI
+func (rr *RegistrationReflector) encodeProxyUri(targetURI string) string {
+	return fmt.Sprintf("http://localhost:%d/!%d!", rr.server.Port(), hashString(targetURI))
 }
 
-func (rr *RegistrationReflector) ProxyURI() string {
-	_, err := rr.Start()
-	if err != nil {
-		panic(fmt.Sprintf("failed to start registration reflector: %v", err))
+func (rr *RegistrationReflector) getHash(part string) string {
+	// Check if the part is a valid hash (a number)
+	if !strings.HasPrefix(part, "!") || !strings.HasSuffix(part, "!") {
+		return ""
 	}
-	return fmt.Sprintf("http://localhost:%d", rr.server.Port())
+	return part[1 : len(part)-1]
+}
+
+func (rr *RegistrationReflector) parseTargetUri(proxyPath string) (*proxyEntry, string, error) {
+	path := strings.TrimLeft(proxyPath, "/")
+	slash := strings.Index(path, "/")
+	beforeSlash := path
+	remainder := "/"
+	if slash != -1 {
+		beforeSlash = path[:slash]
+		remainder = path[slash:]
+	}
+	hash := rr.getHash(beforeSlash)
+	if hash == "" {
+		// find the default proxy entry
+		if entry, exists := rr.targets["default"]; exists {
+			// Found the default proxy entry
+			return &entry, proxyPath, nil
+		} else {
+			// No default proxy entry found, return an error
+			return nil, "", fmt.Errorf("no default proxy entry found for path: %s", proxyPath)
+		}
+	}
+
+	for _, entry := range rr.targets {
+		if entry.hashCode == hash {
+			// Found the target URI
+			return &entry, remainder, nil
+		}
+	}
+
+	return nil, "", fmt.Errorf("no proxy entry found for path: %s", proxyPath)
+}
+
+func (rr *RegistrationReflector) ProxyURI(target string) string {
+	proxy, err := rr.getProxy(target, false)
+	if err != nil {
+		rr.logger.Error("Failed to get proxy URI", zap.Error(err))
+		return target
+	}
+	return proxy.proxyURI
+}
+
+func (rr *RegistrationReflector) DefaultProxyURI(target string) string {
+	_, err := rr.getProxy(target, true)
+	if err != nil {
+		rr.logger.Error("Failed to get proxy URI", zap.Error(err))
+		return target
+	}
+	return target
 }
 func (rr *RegistrationReflector) RegisterRoutes(mux *mux.Router) error {
 	mux.PathPrefix("/").Handler(rr)
@@ -131,6 +218,23 @@ func (rr *RegistrationReflector) RegisterRoutes(mux *mux.Router) error {
 
 func (rr *RegistrationReflector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
-	// Serve the request using the proxy handler
-	rr.proxyHandler.ServeHTTP(w, r)
+	entry, newPath, err := rr.parseTargetUri(r.URL.Path)
+	if err != nil {
+		rr.logger.Error("Failed to parse target URI", zap.Error(err))
+		http.Error(w, "Invalid target URI", http.StatusBadRequest)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if !strings.HasPrefix(newPath, "/") {
+		newPath = "/" + newPath
+	}
+	r.URL.Path = newPath
+	entry.handler.ServeHTTP(w, r)
+}
+
+func hashString(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
 }


### PR DESCRIPTION
Sends all broker traffic through the agent, which allows for

- Better handling of certs and proxies
- Telemetry for what's happening with relay traffic.