### PR TITLE
Rename ACCEPT_FILE_DIRS to ACCEPTFILE_DIRS to avoid broker error logging

### DIFF
--- a/agent/cmd/serve_test.go
+++ b/agent/cmd/serve_test.go
@@ -131,7 +131,7 @@ func TestBuildRelayStack(t *testing.T) {
 		"BROKER_SERVER_URL": "http://broker.cortex.io",
 		"BROKER_TOKEN":      "abcd1234",
 		"SNYK_BROKER_PATH":  "bash",
-		"ACCEPT_FILE_DIR":   "../server/snykbroker/accept_files",
+		"ACCEPTFILE_DIR":    "../server/snykbroker/accept_files",
 		"GITHUB_TOKEN":      "the-token",
 		"GITHUB_API":        "api.github.com",
 		"GITHUB_GRAPHQL":    "api.github.com/graphql",

--- a/agent/common/integration.go
+++ b/agent/common/integration.go
@@ -233,7 +233,7 @@ type Config struct {
 }
 
 func (ii IntegrationInfo) getIntegrationFileContents(fileName string) (string, error) {
-	acceptFileDir := os.Getenv("ACCEPT_FILE_DIR")
+	acceptFileDir := os.Getenv("ACCEPTFILE_DIR")
 
 	if acceptFileDir == "" {
 		acceptFileDir = "server/snykbroker/accept_files"

--- a/agent/common/integration_test.go
+++ b/agent/common/integration_test.go
@@ -114,7 +114,7 @@ func setAcceptFileDir(t *testing.T) {
 	pwd, err := os.Getwd()
 	require.NoError(t, err)
 	acceptFileDir := path.Join(pwd, "..", "server", "snykbroker", "accept_files")
-	os.Setenv("ACCEPT_FILE_DIR", acceptFileDir)
+	os.Setenv("ACCEPTFILE_DIR", acceptFileDir)
 }
 
 func loadAcceptFile(t *testing.T, integration Integration) (string, error) {

--- a/agent/server/snykbroker/relay_instance_manager_test.go
+++ b/agent/server/snykbroker/relay_instance_manager_test.go
@@ -232,7 +232,7 @@ func (w *wrappedRelayInstanceManager) Instance() *relayInstanceManager {
 
 func createTestRelayInstanceManager(t *testing.T, controller *gomock.Controller, expectedError error, useReflector bool) *wrappedRelayInstanceManager {
 	envVars := map[string]string{
-		"ACCEPT_FILE_DIR":  "./accept_files",
+		"ACCEPTFILE_DIR":   "./accept_files",
 		"GITHUB_TOKEN":     "the-token",
 		"GITHUB_API":       "https://api.github.com",
 		"GITHUB_GRAPHQL":   "https://api.github.com/graphql",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN make -C /build setup proto
 RUN cd /build && go build -o /agent/cortex-axon-agent
 RUN rm -rf /build
 COPY agent/server/snykbroker/accept_files /agent/accept_files
-ENV ACCEPT_FILE_DIR=/agent/accept_files
+ENV ACCEPTFILE_DIR=/agent/accept_files
 
 COPY /scaffold/. /app/scaffold/.
 


### PR DESCRIPTION
Broker warns on `ACCEPT_FILE_*` env vars even though this one is private to us.