### PR TITLE
Ensure HTTP_PORT is used everywhere

### DIFF
--- a/agent/cmd/serve_test.go
+++ b/agent/cmd/serve_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -53,14 +52,6 @@ func TestBuildServeStack(t *testing.T) {
 	app.Stop(context.Background())
 }
 
-func getRandomPort() int {
-	port := 10000 + rand.Intn(50000-10000)
-	if port == 0 {
-		port = 10000
-	}
-	return port
-}
-
 func TestBuildServeStackLive(t *testing.T) {
 
 	// create a fake server that serves http://localhost:xxx/relay/register
@@ -81,8 +72,8 @@ func TestBuildServeStackLive(t *testing.T) {
 	os.Setenv("CORTEX_API_BASE_URL", server.URL)
 	os.Setenv("PORT", "0")
 	config := config.NewAgentEnvConfig()
-	config.HttpServerPort = getRandomPort()
-	config.WebhookServerPort = getRandomPort()
+	config.HttpServerPort = common.GetRandomPort()
+	config.WebhookServerPort = common.GetRandomPort()
 	stack := buildServeStack(&cobra.Command{}, config)
 
 	require.NotNil(t, stack)
@@ -142,8 +133,8 @@ func TestBuildRelayStack(t *testing.T) {
 
 	config := config.NewAgentEnvConfig()
 	config.FailWaitTime = time.Millisecond
-	config.HttpServerPort = getRandomPort()
-	config.WebhookServerPort = getRandomPort()
+	config.HttpServerPort = common.GetRandomPort()
+	config.WebhookServerPort = common.GetRandomPort()
 	// Set a random port for the HTTP server
 	stack := buildRelayStack(&cobra.Command{}, config, common.IntegrationInfo{
 		Integration: common.IntegrationGithub,

--- a/agent/cmd/stack.go
+++ b/agent/cmd/stack.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cortexapps/axon/server"
 	"github.com/cortexapps/axon/server/api"
 	"github.com/cortexapps/axon/server/handler"
-	"github.com/cortexapps/axon/server/http"
 	cortexHttp "github.com/cortexapps/axon/server/http"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
@@ -32,10 +31,10 @@ func startAgent(opts fx.Option) {
 }
 
 var AgentModule = fx.Module("agent",
-	fx.Provide(http.NewPrometheusRegistry),
+	fx.Provide(cortexHttp.NewPrometheusRegistry),
 	fx.Provide(createHttpTransport),
 	fx.Provide(createHttpClient),
-	fx.Provide(http.NewAxonHandler),
+	fx.Provide(cortexHttp.NewAxonHandler),
 	fx.Provide(createMainHttpServer),
 	fx.Provide(func(config config.AgentConfig) *zap.Logger {
 

--- a/agent/common/integration.go
+++ b/agent/common/integration.go
@@ -70,10 +70,10 @@ type IntegrationInfo struct {
 	AcceptFilePath string
 }
 
-func (ii IntegrationInfo) AcceptFile() (string, error) {
+func (ii IntegrationInfo) AcceptFile(localhostBase string) (string, error) {
 
 	// load/locate the accept file then fix it up to have
-	// an entry to talk to the neuroh HTTP server itself
+	// an entry to talk to the axon HTTP server itself
 	// which we use for status, etc
 	alias := ii.Alias
 	if len(alias) == 0 {
@@ -122,7 +122,7 @@ func (ii IntegrationInfo) AcceptFile() (string, error) {
 	entry := map[string]string{
 		"method": "any",
 		"path":   "/__axon/*",
-		"origin": "http://localhost",
+		"origin": localhostBase,
 	}
 	dict["private"] = append([]interface{}{entry}, entries...)
 
@@ -178,7 +178,7 @@ func (ii IntegrationInfo) RewriteOrigins(acceptFilePath string, writer func(stri
 			return acceptFilePath, fmt.Errorf("failed to parse origin %q: %w", origin, err)
 		}
 
-		if parsed.Host == "localhost" || parsed.Host == "127.0.0.1" {
+		if strings.HasPrefix(parsed.Host, "localhost") || strings.HasPrefix(parsed.Host, "127.0.0.1") {
 			continue
 		}
 		if parsed.Scheme == "" {

--- a/agent/common/util.go
+++ b/agent/common/util.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"math/rand"
 	"os"
 )
 
@@ -9,4 +10,12 @@ func ApplyEnv(envVars map[string]string) {
 	for k, v := range envVars {
 		os.Setenv(k, v)
 	}
+}
+
+func GetRandomPort() int {
+	port := 10000 + rand.Intn(50000-10000)
+	if port == 0 {
+		port = 10000
+	}
+	return port
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -61,6 +61,10 @@ type AgentConfig struct {
 	HttpRelayReflectorMode RelayReflectorMode
 }
 
+func (ac AgentConfig) HttpBaseUrl() string {
+	return fmt.Sprintf("http://localhost:%d", ac.HttpServerPort)
+}
+
 func (ac AgentConfig) Print() {
 	fmt.Println("Agent Configuration:")
 	if ac.GrpcPort != DefaultGrpcPort {

--- a/agent/server/api/cortex_api_proxy_handler.go
+++ b/agent/server/api/cortex_api_proxy_handler.go
@@ -63,7 +63,6 @@ func (a *apiProxyHandler) Path() string {
 
 func (a *apiProxyHandler) RegisterRoutes(mux *mux.Router) error {
 	mux.PathPrefix(cortexApiPathRoot).Handler(a)
-	mux.Handle("/", a)
 	return nil
 }
 

--- a/agent/server/api/cortex_api_test.go
+++ b/agent/server/api/cortex_api_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	pb "github.com/cortexapps/axon/.generated/proto/github.com/cortexapps/axon"
+	"github.com/cortexapps/axon/common"
 	"github.com/cortexapps/axon/config"
 	cortex_http "github.com/cortexapps/axon/server/http"
 	"github.com/stretchr/testify/require"
@@ -157,7 +158,7 @@ func mockServer(t *testing.T, cfg config.AgentConfig, handler http.HandlerFunc) 
 		cfg.CortexApiBaseUrl = "http://dryrun" // should never be called
 	}
 
-	cfg.HttpServerPort = 0
+	cfg.HttpServerPort = common.GetRandomPort()
 	proxy := NewApiProxyHandler(cfg, logger, nil)
 	httpServerParams := cortex_http.HttpServerParams{
 		Logger: logger,
@@ -166,6 +167,7 @@ func mockServer(t *testing.T, cfg config.AgentConfig, handler http.HandlerFunc) 
 	proxyServer.RegisterHandler(proxy)
 	port, err := proxyServer.Start()
 	require.NoError(t, err)
+	require.Equal(t, port, cfg.HttpServerPort)
 
 	cfg.HttpServerPort = port
 

--- a/agent/server/api/http_helper.go
+++ b/agent/server/api/http_helper.go
@@ -22,7 +22,7 @@ type httpRequestHelper struct {
 
 func newHttpRequestHelper(config config.AgentConfig, logger *zap.Logger) *httpRequestHelper {
 	return &httpRequestHelper{
-		BaseURL: fmt.Sprintf("http://localhost:%d/cortex-api", config.HttpServerPort),
+		BaseURL: fmt.Sprintf("%s/%s", config.HttpBaseUrl(), cortexApiRoot),
 		logger:  logger.With(zap.String("component", "httpRequestHelper")),
 	}
 }

--- a/agent/server/http/http_server.go
+++ b/agent/server/http/http_server.go
@@ -136,7 +136,10 @@ func NewHttpServer(p HttpServerParams, opts ...ServerOption) Server {
 	if p.Lifecycle != nil {
 		p.Lifecycle.Append(fx.Hook{
 			OnStart: func(ctx context.Context) error {
-				_, err := server.Start()
+				port, err := server.Start()
+				if err != nil && serverOpts.port != 0 && port != serverOpts.port {
+					panic("Port mismatch: server started on a different port than expected")
+				}
 				p.Logger.Info("HTTP server started", zap.Int("port", serverOpts.port), zap.Error(err))
 				return err
 			},

--- a/agent/server/snykbroker/relay_instance_manager.go
+++ b/agent/server/snykbroker/relay_instance_manager.go
@@ -299,7 +299,7 @@ func (r *relayInstanceManager) Start() error {
 		executable = directPath
 	}
 
-	acceptFile, err := r.integrationInfo.AcceptFile()
+	acceptFile, err := r.integrationInfo.AcceptFile(r.config.HttpBaseUrl())
 
 	if err != nil {
 		fmt.Println("Error getting accept file", err)

--- a/agent/test/relay/relay_test.sh
+++ b/agent/test/relay/relay_test.sh
@@ -18,6 +18,7 @@ set -e
 export TOKEN=0e481b34-76ac-481a-a92f-c94a6cf6f6c1
 export SERVER_PORT=57341
 
+
 if [ "$PROXY" == "1" ]
 then
     echo "TESTING WITH PROXY"
@@ -25,6 +26,10 @@ then
 else 
     echo "TESTING WITHOUT PROXY"
     export ENVFILE=noproxy.env
+
+    # just for fun also set the HTTP_PORT to a different value to ensure
+    # we respect that port as well
+    export HTTP_PORT=58080
 fi
 
 # Create an exit trap to stop the broker when the script exits


### PR DESCRIPTION
There are cases where root containers can not bind to 80 so we need to run the agent HTTP server on a different port.  This was mostly in there but there were a few places that were assuming 80, this fixes that.