### PR TITLE
Fix webhook routing, add E2E test

### DIFF
--- a/agent/cmd/serve_test.go
+++ b/agent/cmd/serve_test.go
@@ -105,7 +105,7 @@ func testAxonHealthcheck(t *testing.T, port int) {
 }
 
 func testWebhook(t *testing.T, port int) {
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/webhook/12345", port))
+	resp, err := http.Post(fmt.Sprintf("http://localhost:%d/webhook/12345", port), "application/json", nil)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/agent/server/http/http_server_webhook_test.go
+++ b/agent/server/http/http_server_webhook_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cortexapps/axon/config"
 	"github.com/cortexapps/axon/server/cron"
 	"github.com/cortexapps/axon/server/handler"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -38,7 +39,9 @@ func TestHandleWebhook(t *testing.T) {
 	require.NoError(t, err)
 
 	webhookHandler := NewWebhookHandler(config.AgentConfig{}, logger, manager, nil)
-	ts := httptest.NewServer(webhookHandler)
+	mux := mux.NewRouter()
+	webhookHandler.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
 
 	// The handler should not have been invoked yet
 	assert.Nil(t, manager.GetByTag("my-webhook-id").LastInvoked())

--- a/scaffold/go/main.go
+++ b/scaffold/go/main.go
@@ -24,9 +24,9 @@ func main() {
 		),
 	)
 
-	_, err = agentClient.RegisterHandler(myExampleWebhooklHandler,
+	_, err = agentClient.RegisterHandler(myExampleWebhookHandler,
 		axon.WithInvokeOption(
-			pb.HandlerInvokeType_WEBHOOK, "my-webhook-id",
+			pb.HandlerInvokeType_WEBHOOK, "my-webhook-1",
 		),
 	)
 
@@ -87,11 +87,11 @@ func myExampleIntervalHandler(ctx axon.HandlerContext) interface{} {
 }
 
 // Here we have our example handler that will be called every one second
-func myExampleWebhooklHandler(ctx axon.HandlerContext) interface{} {
+func myExampleWebhookHandler(ctx axon.HandlerContext) interface{} {
 
 	body := ctx.Args()["body"]
 	contentType := ctx.Args()["content-type"]
 
-	ctx.Logger().Info("Hello from myExampleIntervalHandler!", zap.String("body", body), zap.String("content-type", contentType))
+	ctx.Logger().Info("Hello from myExampleWebhookHandler webhook handler!", zap.String("body", body), zap.String("content-type", contentType))
 	return nil
 }


### PR DESCRIPTION
Issue:

Webhook invocation has unit tests but they had a subtle bug that didn't handle child routes properly when we switched to Gorilla Mux

This change:

- Fixes that issue
- Fixes the unit test
- Adds E2E scenario checking for webhooks so they can't get broken again