### PR TITLE
Move to header resolver

### DIFF
--- a/agent/common/integration_headers_test.go
+++ b/agent/common/integration_headers_test.go
@@ -31,7 +31,7 @@ func TestRewriteOriginsWithHeaderExtraction(t *testing.T) {
 						"method": "GET",
 						"path":   "/api/*",
 						"origin": "https://api.example.com",
-						"headers": map[string]interface{}{
+						"headers": map[string]any{
 							"x-api-key": "${TEST_API_KEY}",
 							"x-static":  "static-value",
 						},
@@ -145,11 +145,11 @@ func TestRewriteOriginsWithHeaderExtraction(t *testing.T) {
 
 			// Capture header extraction calls
 			var headerCalls []headerCall
-			headerExtractor := func(origin string, headers map[string]string) string {
+			headerExtractor := func(origin string, headers ResolverMap) string {
 				if len(headers) > 0 {
 					headerCalls = append(headerCalls, headerCall{
 						origin:  origin,
-						headers: headers,
+						headers: headers.Resolve(),
 					})
 				}
 				return "proxy-" + origin // Mocking the proxy URI generation
@@ -205,13 +205,13 @@ func TestHeaderEnvironmentVariableResolution(t *testing.T) {
 	}
 
 	var capturedHeaders map[string]string
-	headerExtractor := func(_ string, headers map[string]string) {
-		capturedHeaders = headers
+	headerExtractor := func(_ string, headers ResolverMap) {
+		capturedHeaders = headers.Resolve()
 	}
 
 	_, err := integrationInfo.RewriteOrigins(
 		acceptFile,
-		func(originalURI string, headers map[string]string) string {
+		func(originalURI string, headers ResolverMap) string {
 			headerExtractor(originalURI, headers)
 			return originalURI
 		},
@@ -258,8 +258,8 @@ func TestComplexEnvironmentVariablePatterns(t *testing.T) {
 	}
 
 	var capturedHeaders map[string]string
-	headerExtractor := func(origin string, headers map[string]string) string {
-		capturedHeaders = headers
+	headerExtractor := func(origin string, headers ResolverMap) string {
+		capturedHeaders = headers.Resolve()
 		return origin
 	}
 
@@ -301,8 +301,8 @@ func TestEmptyAndInvalidHeaderValues(t *testing.T) {
 	}
 
 	var capturedHeaders map[string]string
-	headerExtractor := func(origin string, headers map[string]string) string {
-		capturedHeaders = headers
+	headerExtractor := func(origin string, headers ResolverMap) string {
+		capturedHeaders = headers.Resolve()
 		return origin
 	}
 

--- a/agent/common/integration_test.go
+++ b/agent/common/integration_test.go
@@ -201,7 +201,7 @@ func TestAcceptRewrite(t *testing.T) {
 		Integration:    IntegrationGithub,
 		AcceptFilePath: acceptFilePath,
 	}
-	rewritten, err := info.RewriteOrigins(acceptFilePath, func(origin string, headers map[string]string) string {
+	rewritten, err := info.RewriteOrigins(acceptFilePath, func(origin string, headers ResolverMap) string {
 
 		if strings.Contains(origin, "http://localhost") {
 			require.Fail(t, "should not rewrite localhost origins")

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -233,11 +233,14 @@ func NewAgentEnvConfig() AgentConfig {
 		cfg.HttpCaCertFilePath = filepath.Clean(cfg.HttpCaCertFilePath)
 	}
 
+	cfg.HttpRelayReflectorMode = RelayReflectorAllTraffic
 	if relayReflector := os.Getenv("ENABLE_RELAY_REFLECTOR"); relayReflector != "" {
 		switch relayReflector {
-		case "true", "registration":
+		case "false", "disabled":
+			cfg.HttpRelayReflectorMode = RelayReflectorDisabled
+		case "registration":
 			cfg.HttpRelayReflectorMode = RelayReflectorRegistrationOnly
-		case "all":
+		case "true", "all":
 			cfg.HttpRelayReflectorMode = RelayReflectorAllTraffic
 		}
 	}

--- a/agent/server/snykbroker/reflector_headers_simple_test.go
+++ b/agent/server/snykbroker/reflector_headers_simple_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cortexapps/axon/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -39,7 +40,7 @@ func TestHeaderApplicationInProxy(t *testing.T) {
 	}
 
 	// Create proxy with headers
-	proxyEntry, err := newProxyEntry(backendServer.URL, false, 8080, headers, nil)
+	proxyEntry, err := newProxyEntry(backendServer.URL, false, 8080, common.NewResolverMapFromMap(headers), nil)
 	proxyEntry.addResponseHeader("x-response", "response-value")
 	require.NoError(t, err)
 	require.NotNil(t, proxyEntry)
@@ -97,7 +98,7 @@ func TestMultipleProxiesWithDifferentHeaders(t *testing.T) {
 		"x-api-key": "key-for-server-1",
 		"x-service": "service-1",
 	}
-	proxy1, err := newProxyEntry(server1.URL, false, 8080, headers1, nil)
+	proxy1, err := newProxyEntry(server1.URL, false, 8080, common.NewResolverMapFromMap(headers1), nil)
 	require.NoError(t, err)
 
 	// Create second proxy with different headers
@@ -105,7 +106,7 @@ func TestMultipleProxiesWithDifferentHeaders(t *testing.T) {
 		"x-api-key": "key-for-server-2",
 		"x-service": "service-2",
 	}
-	proxy2, err := newProxyEntry(server2.URL, false, 8080, headers2, nil)
+	proxy2, err := newProxyEntry(server2.URL, false, 8080, common.NewResolverMapFromMap(headers2), nil)
 	require.NoError(t, err)
 
 	// Send requests through both proxies
@@ -205,7 +206,7 @@ func TestHeaderOverwriting(t *testing.T) {
 	}
 
 	// Create proxy with headers
-	proxyEntry, err := reflector.getProxy(backendServer.URL, false, headers)
+	proxyEntry, err := reflector.getProxy(backendServer.URL, false, common.NewResolverMapFromMap(headers))
 	require.NoError(t, err)
 
 	// Create request with original headers

--- a/agent/server/snykbroker/reflector_headers_test.go
+++ b/agent/server/snykbroker/reflector_headers_test.go
@@ -173,10 +173,10 @@ func TestAcceptFileHeadersAppliedToLiveRequests(t *testing.T) {
 
 			info, err := integrationInfo.RewriteOrigins(
 				acceptFile,
-				func(originalURI string, headers map[string]string) string {
+				func(originalURI string, headers common.ResolverMap) string {
 					capturedOrigin = originalURI
-					capturedHeaders = headers
-					return reflector.ProxyURI(originalURI, WithHeaders(headers))
+					capturedHeaders = headers.Resolve()
+					return reflector.ProxyURI(originalURI, WithHeaders(headers.Resolve()))
 				},
 			)
 			require.NoError(t, err)
@@ -247,9 +247,9 @@ func TestAcceptFileHeadersWithMissingEnvVars(t *testing.T) {
 
 	_, err := integrationInfo.RewriteOrigins(
 		acceptFile,
-		func(originalURI string, headers map[string]string) string {
-			capturedHeaders = headers
-			return reflector.ProxyURI(originalURI, WithHeaders(headers))
+		func(originalURI string, headers common.ResolverMap) string {
+			capturedHeaders = headers.Resolve()
+			return reflector.ProxyURI(originalURI, WithHeadersResolver(headers))
 		},
 	)
 	require.NoError(t, err)
@@ -330,9 +330,9 @@ func TestMultipleRoutesWithDifferentHeaders(t *testing.T) {
 	headerExtractionCount := 0
 	info, err := integrationInfo.RewriteOrigins(
 		acceptFile,
-		func(originalURI string, headers map[string]string) string {
+		func(originalURI string, headers common.ResolverMap) string {
 			headerExtractionCount++
-			return reflector.ProxyURI(originalURI, WithHeaders(headers))
+			return reflector.ProxyURI(originalURI, WithHeadersResolver(headers))
 		},
 	)
 	require.NotNil(t, info)

--- a/agent/server/snykbroker/relay_instance_manager.go
+++ b/agent/server/snykbroker/relay_instance_manager.go
@@ -458,9 +458,9 @@ func (r *relayInstanceManager) Start() error {
 func (r *relayInstanceManager) applyAcceptFileTransforms(acceptFile string) string {
 	if r.config.HttpRelayReflectorMode == config.RelayReflectorAllTraffic && r.reflector != nil {
 
-		info, err := r.integrationInfo.RewriteOrigins(acceptFile, func(uri string, headers map[string]string) string {
+		info, err := r.integrationInfo.RewriteOrigins(acceptFile, func(uri string, headers common.ResolverMap) string {
 			r.logger.Info("Rewriting accept file URI", zap.String("uri", uri), zap.Any("headers", headers))
-			return r.reflector.ProxyURI(uri, WithHeaders(headers))
+			return r.reflector.ProxyURI(uri, WithHeadersResolver(headers))
 		})
 
 		if err != nil {


### PR DESCRIPTION
- Step one in supporting header resolution callbacks
- Makes `all` default for `ENABLE_REFLECTOR`