### PR TITLE
Upgrade to trixie

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 WORKDIR /agent
 
 # Install dependencies
-RUN apt update && apt install -y protobuf-compiler git python3.11 python3.11-venv wget build-essential openssl jq
+RUN apt update && apt install -y protobuf-compiler git python3 python3-venv wget build-essential openssl jq
 
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20


### PR DESCRIPTION
There is a [vulnerability](https://github.com/git/git/security/advisories/GHSA-vwqx-4fm8-6qc9) in git 2.39 which `bookworm` uses, so this upgrades to `trivia` which picks up `2.47.3`