### PR TITLE
Fix Trivy CI: filter SARIF results by severity level

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -45,10 +45,10 @@ jobs:
 
       - name: Fail on CRITICAL/HIGH vulnerabilities
         run: |
-          COUNT=$(jq '[.runs[].results[]] | length' trivy-results.sarif)
+          COUNT=$(jq '[.runs[].results[] | select(.level == "error")] | length' trivy-results.sarif)
           if [ "$COUNT" -gt 0 ]; then
             echo "::error::Found $COUNT CRITICAL/HIGH fixable vulnerabilities:"
-            jq -r '.runs[].results[] | "\(.ruleId): \(.message.text | split("\n") | .[0])"' trivy-results.sarif
+            jq -r '.runs[].results[] | select(.level == "error") | "\(.ruleId): \(.message.text | split("\n") | .[0])"' trivy-results.sarif
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- The SARIF output format includes vulnerabilities of all severities regardless of the `--severity` flag passed to Trivy
- The failure check step was counting **all** SARIF results, causing MEDIUM severity CVEs (e.g. `brace-expansion` CVE-2026-33750) to incorrectly fail the build
- Fixed by filtering SARIF results to only count `level == "error"` entries, which corresponds to HIGH/CRITICAL in SARIF spec

## Test plan
- [x] Trigger the Trivy workflow manually on this branch: `gh workflow run trivy.yml --ref fix/trivy-sarif-severity-filter`
- [x] Verify `brace-expansion` (MEDIUM) no longer causes the build to fail
- [x] Verify `path-to-regexp` (HIGH) still causes the build to fail
- workflow link: https://github.com/cortexapps/axon/actions/runs/23963135855/job/69897352285

🤖 Generated with [Claude Code](https://claude.com/claude-code)