### PR TITLE
Upgrade snyk broker to v1.0.10-axon

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y protobuf-compiler
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20
 
-ARG SNYK_BROKER_VERSION=v1.0.9-axon
+ARG SNYK_BROKER_VERSION=v1.0.10-axon
 RUN wget -q -O - https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && apt-get install -y nodejs
 RUN npm install --global npm@latest typescript@4.9.3
 RUN git clone https://github.com/cortexapps/snyk-broker.git /tmp/snyk-broker && \


### PR DESCRIPTION
## Summary
- Bump `SNYK_BROKER_VERSION` from `v1.0.9-axon` to `v1.0.10-axon`
- Removes manual `npm install axios@1.15.0` hotfix — the axios upgrade is now included in the snyk-broker release (cortexapps/snyk-broker#14)
- Fixes **CVE-2025-62718** (critical SSRF via NO_PROXY Hostname Normalization Bypass in axios)

## Test plan
- [ ] Docker image builds successfully
- [ ] Trivy scan passes with no new CRITICAL/HIGH vulns from snyk-broker
- [ ] Broker relay connects and proxies requests correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)