### PR TITLE
Preserve %2F through the relay reflector hop

### DIFF
--- a/agent/server/snykbroker/reflector.go
+++ b/agent/server/snykbroker/reflector.go
@@ -285,7 +285,15 @@ func (rr *RegistrationReflector) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		fields = append(fields, zap.String("connection", r.Header.Get("Connection")))
 	}
 	rr.logger.Debug("Reflector request", fields...)
-	entry, newPath, err := rr.parseTargetUri(r.URL.Path)
+	// Parse against the escaped (raw) path so that percent-encoded characters
+	// such as %2F in mid-path segments (e.g. GitLab namespace/project IDs)
+	// survive this hop. r.URL.Path is always percent-decoded; slicing it
+	// silently loses %2F, and writing r.URL.Path without also updating
+	// r.URL.RawPath causes EscapedPath() — which the downstream reverse proxy
+	// uses on the wire — to fall back to PathEscape(Path), which does not
+	// re-encode '/'.
+	escapedPath := r.URL.EscapedPath()
+	entry, newPath, err := rr.parseTargetUri(escapedPath)
 	if err != nil {
 		rr.logger.Error("Failed to find Entry for target URI", zap.Error(err))
 		http.Error(w, "Invalid target URI", http.StatusBadGateway)
@@ -296,7 +304,14 @@ func (rr *RegistrationReflector) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	if !strings.HasPrefix(newPath, "/") {
 		newPath = "/" + newPath
 	}
-	r.URL.Path = newPath
+	decodedPath, err := url.PathUnescape(newPath)
+	if err != nil {
+		rr.logger.Error("Failed to decode target path", zap.Error(err))
+		http.Error(w, "Invalid target path", http.StatusBadRequest)
+		return
+	}
+	r.URL.Path = decodedPath
+	r.URL.RawPath = newPath
 	rr.logger.Debug("Proxying request",
 		zap.String("targetURI", entry.TargetURI),
 		zap.String("proxyURI", entry.proxyURI),

--- a/agent/server/snykbroker/reflector_test.go
+++ b/agent/server/snykbroker/reflector_test.go
@@ -651,3 +651,78 @@ func TestWebSocketProxyWithoutTransport(t *testing.T) {
 	require.NotNil(t, wsProxy)
 	require.False(t, wsProxy.IsConnected())
 }
+
+// The reflector must preserve percent-encoded characters (notably %2F) in the
+// path when forwarding to the registered target. Reading from r.URL.Path alone
+// and writing back to r.URL.Path without updating r.URL.RawPath causes Go's
+// reverse-proxy to emit the decoded path on the wire, which turns a GitLab
+// namespace/project identifier like `foo%2Fbar` into `foo/bar` and makes
+// GitLab return 404 for anything past the project segment.
+func TestServeHTTP_PreservesPercentEncodedSlashMidPath(t *testing.T) {
+	env := newTestReflectorEnv(t)
+
+	var gotEscapedPath string
+	env.Router.PathPrefix("/api/").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	proxyURI := env.Reflector.ProxyURI(env.Server.URL)
+
+	const encoded = "/api/v4/projects/test.project%2Fcli-functional-test-xxx/approval_rules"
+	req, err := http.NewRequest("GET", proxyURI+encoded, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Equal(t, encoded, gotEscapedPath,
+		"mid-path %%2F must survive the reflector hop")
+}
+
+func TestServeHTTP_PreservesPercentEncodedSlashTrailing(t *testing.T) {
+	env := newTestReflectorEnv(t)
+
+	var gotEscapedPath string
+	env.Router.PathPrefix("/api/").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	proxyURI := env.Reflector.ProxyURI(env.Server.URL)
+
+	const encoded = "/api/v4/projects/test.project%2Fcli-functional-test-xxx"
+	req, err := http.NewRequest("GET", proxyURI+encoded, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Equal(t, encoded, gotEscapedPath,
+		"trailing %%2F must survive the reflector hop")
+}
+
+func TestServeHTTP_PreservesPercentEncodedSlashDefaultTarget(t *testing.T) {
+	env := newTestReflectorEnv(t)
+
+	var gotEscapedPath string
+	env.Router.PathPrefix("/api/").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	proxyURI := env.Reflector.ProxyURI(env.Server.URL, WithDefault(true))
+
+	const encoded = "/api/v4/projects/test.project%2Fcli-functional-test-xxx/approval_rules"
+	req, err := http.NewRequest("GET", proxyURI+encoded, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Equal(t, encoded, gotEscapedPath,
+		"mid-path %%2F must survive the reflector hop in default-target mode")
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y protobuf-compiler
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20
 
-ARG SNYK_BROKER_VERSION=v1.0.10-axon
+ARG SNYK_BROKER_VERSION=v1.0.11-axon
 RUN wget -q -O - https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && apt-get install -y nodejs
 RUN npm install --global npm@latest typescript@4.9.3
 RUN git clone https://github.com/cortexapps/snyk-broker.git /tmp/snyk-broker && \


### PR DESCRIPTION
## Summary
- `RegistrationReflector.ServeHTTP` read `r.URL.Path` (always decoded) and wrote back to `r.URL.Path` without updating `r.URL.RawPath`. That left `RawPath` inconsistent with `Path`, so Go's `url.EscapedPath()` — used by the downstream reverse proxy on the wire — fell back to `url.PathEscape(Path)`, which does not re-encode `/`. Result: `%2F` in a mid-path segment was emitted to the target as a literal `/`.
- Impact: GitLab namespace/project identifiers like `foo%2Fbar` survived the upstream `relay-dispatcher` but were silently decoded by the reflector. Any GitLab API call with a subresource after the project (e.g. `.../projects/foo%2Fbar/approval_rules`) reached GitLab as `.../projects/foo/bar/approval_rules` and 404'd. Numeric project IDs were unaffected.
- Fix: parse against `r.URL.EscapedPath()` so `parseTargetUri` operates on the encoded form, then write back both `r.URL.Path` (decoded via `url.PathUnescape`) and `r.URL.RawPath` consistently, so `EscapedPath()` returns the original encoding on the wire.

## Test plan
- [x] `go test ./server/snykbroker/...` — full suite green.
- [x] `go test ./...` across the agent — no regressions.
- [x] Three new regression tests added in `reflector_test.go` (mid-path `%2F`, trailing `%2F`, default-target mode). Verified they FAIL on pre-patch code (mid-path + trailing) and PASS on post-patch.
- [ ] End-to-end smoke test against a real GitLab namespace/project (`.../projects/<ns>%2F<proj>/approval_rules`) once this lands in a broker image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)