### PR TITLE
Fix Trivy CI: pin libngtcp2 to patched deb13u1 for CVE-2026-40170

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,13 +26,6 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -64,8 +57,6 @@ jobs:
             BUILD_VERSION=${{ github.ref_name }}-${{ github.sha }}
           # arm64 via QEMU is slow, so only build it on main branch or tags (not workflow_dispatch)
           platforms: ${{ env.IS_ARM64_BUILD == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
           load: ${{ env.IS_PUBLISH != 'true' }}
 
       - name: Determine local image tag

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,13 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v5
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -57,6 +64,8 @@ jobs:
             BUILD_VERSION=${{ github.ref_name }}-${{ github.sha }}
           # arm64 via QEMU is slow, so only build it on main branch or tags (not workflow_dispatch)
           platforms: ${{ env.IS_ARM64_BUILD == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
           load: ${{ env.IS_PUBLISH != 'true' }}
 
       - name: Determine local image tag

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,6 +76,14 @@ ENV CORTEX_API_BASE_URL=https://api.getcortexapp.com
 ENV HANDLER_HISTORY_PATH=/var/log/axon/history
 ENV NODE_OPTIONS=--use-openssl-ca
 
+# Final security upgrade: BUILD_VERSION cache-busts this layer on every commit,
+# so transitive deps installed after the earlier upgrade (e.g. libngtcp2 via
+# the nodesource-pulled curl) pick up the latest security patches.
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 50051
 
 ENTRYPOINT [ "/agent/entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,8 +21,14 @@ RUN cd /build && go build -o /agent/cortex-axon-agent
 FROM debian:stable-slim
 WORKDIR /agent
 
-# Install dependencies
-RUN apt-get update && apt-get upgrade -y && apt-get install -y protobuf-compiler git python3 python3-venv wget build-essential openssl jq
+# Install dependencies. libngtcp2-16 and libngtcp2-crypto-gnutls8 are pinned
+# to the patched 1.11.0-1+deb13u1 to address CVE-2026-40170; they're pulled
+# transitively via wget -> libcurl3-gnutls. Bump these pins if Debian ships
+# a newer fix or the current version ages out of the archive.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    protobuf-compiler git python3 python3-venv wget build-essential openssl jq \
+    libngtcp2-16=1.11.0-1+deb13u1 \
+    libngtcp2-crypto-gnutls8=1.11.0-1+deb13u1
 
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20
@@ -75,14 +81,6 @@ ENV AXON_BUILD_VERSION=${BUILD_VERSION}
 ENV CORTEX_API_BASE_URL=https://api.getcortexapp.com
 ENV HANDLER_HISTORY_PATH=/var/log/axon/history
 ENV NODE_OPTIONS=--use-openssl-ca
-
-# Final security upgrade: BUILD_VERSION cache-busts this layer on every commit,
-# so transitive deps installed after the earlier upgrade (e.g. libngtcp2 via
-# the nodesource-pulled curl) pick up the latest security patches.
-RUN apt-get update \
- && apt-get upgrade -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 50051
 


### PR DESCRIPTION
## Summary

Scheduled Trivy scan ([run 24774918919](https://github.com/cortexapps/axon/actions/runs/24774918919/job/72490566197)) flagged 2 fixable HIGH CVEs on `:main`:

- `CVE-2026-40170` → `libngtcp2-16`
- `CVE-2026-40170` → `libngtcp2-crypto-gnutls8`

Stack buffer overflow in ngtcp2's QUIC qlog code. Fixed upstream in Debian trixie as `1.11.0-1+deb13u1`.

## Where the package comes from

Not the base image — `debian:stable-slim` doesn't contain curl or libngtcp2. It's pulled transitively on Dockerfile line 25 via **`wget` → `libcurl3-gnutls` → `libngtcp2-16`**. The upgrade on that same line *should* pick up the fix, but the entire RUN layer is being served from buildx cache on CI, so stale pre-fix packages are frozen in the cached layer.

## Fix

Pin `libngtcp2-16` and `libngtcp2-crypto-gnutls8` to `1.11.0-1+deb13u1` in the runtime-stage `apt-get install`:

```dockerfile
RUN apt-get update && apt-get upgrade -y && apt-get install -y \
    protobuf-compiler git python3 python3-venv wget build-essential openssl jq \
    libngtcp2-16=1.11.0-1+deb13u1 \
    libngtcp2-crypto-gnutls8=1.11.0-1+deb13u1
```

The pin changes the RUN command text, which busts the buildx cache key for this layer → fresh install with the patched version. Subsequent builds deterministically include the fix.

## Verification

Built locally with `docker buildx build --platform linux/amd64 --no-cache`:

- `dpkg -l libngtcp2-16 libngtcp2-crypto-gnutls8`: both at `1.11.0-1+deb13u1` (patched)
- `trivy image --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs usr/lib/node_modules/npm,usr/local/go`: **0 fixable findings**; `CVE-2026-40170` gone

## Trade-off / maintenance note

Pinning is the narrowest possible fix, but it comes with ongoing cost:

- **Next transitive-dep CVE = another PR.** If a future CVE lands in libxml2, openssl, libcurl, etc., the cache-staleness issue will reappear for that package and someone will need to add another pin.
- **Pins can block apt upgrades.** If Debian releases a `deb13u2` with an additional fix, these pins won't pick it up automatically.
- **Pins can break builds.** If the `deb13u1` point release eventually ages out of `deb.debian.org`'s stable archive, this build will fail with "no installation candidate" until someone bumps the pin.

Out-of-scope alternatives we can revisit if this pattern recurs:
- Removing the persistent buildx cache (matches sibling convention: brain-backend and brain-app don't cache buildx layers).
- A weekly `APT_CACHE_BUST` build-arg that forces the apt layer to rebuild on a schedule while preserving other cache benefits.

## Test plan

- [ ] Docker image build job succeeds on this PR
- [ ] PR's Trivy scan (`trivy-pr` job in `docker.yml`) reports no HIGH/CRITICAL fixable findings
- [ ] Future scheduled Trivy scan against `:main` (after this lands) is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)