### PR TITLE
Upgrade snyk-broker to v1.0.13-axon and bump Go to 1.26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
 
       - name: Install dependencies
         run: |
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
 
       - name: Install dependencies
         run: |

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/cortexapps/axon
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20
 
-ARG SNYK_BROKER_VERSION=v1.0.11-axon
+ARG SNYK_BROKER_VERSION=v1.0.12-axon
 RUN wget -q -O - https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && apt-get install -y nodejs
 RUN npm install --global npm@latest typescript@4.9.3
 RUN git clone https://github.com/cortexapps/snyk-broker.git /tmp/snyk-broker && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stable-slim AS builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y protobuf-compiler git wget build-essential
 
-ENV GOLANG_VERSION=1.26.2
+ENV GOLANG_VERSION=1.26.3
 RUN wget -q "https://dl.google.com/go/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz" -O /tmp/go.tar.gz \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20
 
-ARG SNYK_BROKER_VERSION=v1.0.12-axon
+ARG SNYK_BROKER_VERSION=v1.0.13-axon
 RUN wget -q -O - https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && apt-get install -y nodejs
 RUN npm install --global npm@latest typescript@4.9.3
 RUN git clone https://github.com/cortexapps/snyk-broker.git /tmp/snyk-broker && \
@@ -50,7 +50,7 @@ RUN git clone https://github.com/cortexapps/snyk-broker.git /tmp/snyk-broker && 
 ENV PATH="/usr/local/lib/node_modules/.bin:${PATH}"
 
 # Install Go (needed by scaffold apps that build on top of this image)
-ENV GOLANG_VERSION=1.26.2
+ENV GOLANG_VERSION=1.26.3
 RUN wget -q "https://dl.google.com/go/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz" -O /tmp/go.tar.gz \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz

--- a/examples/go/axon-ev-sync/go.mod
+++ b/examples/go/axon-ev-sync/go.mod
@@ -1,6 +1,6 @@
 module github.com/cortexapps/axon_apps/axon-ev-sync
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/cortexapps/axon-go v0.0.0

--- a/scaffold/go/axon_client/go.mod
+++ b/scaffold/go/axon_client/go.mod
@@ -1,6 +1,6 @@
 module github.com/cortexapps/axon-go
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0

--- a/scaffold/go/go.mod
+++ b/scaffold/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/cortexapps/axon_apps/{{.ProjectName}}
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/cortexapps/axon-go
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary

Three image-level security fixes rolled into one PR.

### snyk-broker `v1.0.11-axon` → `v1.0.13-axon`
Picks up two upstream PRs:
- cortexapps/snyk-broker#20 — **uuid** 8.3.x → 14.0.0 to address **GHSA-w5hq-g745-h8pq**. TypeScript also bumped 4.9.3 → 5.6.0 (4.9 was EOL).
- cortexapps/snyk-broker#22 — **axios** → ^1.16.0 to address 13 axios CVEs (`CVE-2026-42033` through `42044` plus `42264`).

### Go `1.26.2` → `1.26.3`
Addresses **8 stdlib CVEs** flagged on the image:
`CVE-2026-33811, 33814, 39820, 39823, 39825, 39826, 39836, 42499` — all fixed in Go 1.26.3.

Bumped consistently in `docker/Dockerfile` (both stages), all `go.mod` files (agent, sdks, scaffold, examples), and `.github/workflows/ci.yml`.

### Image rebuild side-effect
Rebuilding also runs `apt-get update && upgrade -y` in the runtime stage, refreshing `linux-libc-dev` and clearing the linux-libc-dev CVE class accumulating on `:main` since the last build (April 22).

## Test plan

- [ ] Docker build succeeds.
- [ ] PR's `trivy-pr` job clears uuid + axios + linux-libc-dev + Go stdlib findings.
- [ ] After merge, scheduled scan against `:main` reports 0 fixable HIGH/CRITICAL CVEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)