### PR TITLE
Fix Trivy CI: pin libnghttp2-14 to patched deb13u1 for CVE-2026-27135

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,14 +21,16 @@ RUN cd /build && go build -o /agent/cortex-axon-agent
 FROM debian:stable-slim
 WORKDIR /agent
 
-# Install dependencies. libngtcp2-16 and libngtcp2-crypto-gnutls8 are pinned
-# to the patched 1.11.0-1+deb13u1 to address CVE-2026-40170; they're pulled
-# transitively via wget -> libcurl3-gnutls. Bump these pins if Debian ships
-# a newer fix or the current version ages out of the archive.
+# Install dependencies. libngtcp2-16, libngtcp2-crypto-gnutls8, and libnghttp2-14
+# are pinned to patched Debian versions to address CVE-2026-40170 and
+# CVE-2026-27135; they're pulled transitively via wget -> libcurl3-gnutls. Bump
+# these pins if Debian ships a newer fix or the current version ages out of the
+# archive.
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     protobuf-compiler git python3 python3-venv wget build-essential openssl jq \
     libngtcp2-16=1.11.0-1+deb13u1 \
-    libngtcp2-crypto-gnutls8=1.11.0-1+deb13u1
+    libngtcp2-crypto-gnutls8=1.11.0-1+deb13u1 \
+    libnghttp2-14=1.64.0-1.1+deb13u1
 
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20


### PR DESCRIPTION
## Summary

- Today's [Trivy scan](https://github.com/cortexapps/axon/actions/runs/25915434052) failed with one HIGH/CRITICAL fixable vuln: **CVE-2026-27135** in `libnghttp2-14`, pulled transitively via `wget → libcurl3-gnutls` in the runtime image.
- Pins `libnghttp2-14=1.64.0-1.1+deb13u1` (the Debian trixie security-tracker fix) alongside the existing `libngtcp2-*` pins added in #99 for CVE-2026-40170. Same pattern, same justification.

## Test plan

- [ ] CI Trivy scan passes (no HIGH/CRITICAL findings)
- [ ] Image still builds on linux/amd64 and linux/arm64
- [ ] Local `trivy image --severity HIGH,CRITICAL --ignore-unfixed` on the rebuilt image confirms CVE-2026-27135 drops

Session: d85c2c45 · Worktree: axon/primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)