### PR TITLE
Clear Trivy: APT_CACHE_BUST + snyk-broker v1.0.14-axon + drop hard pins

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "apt cache bust: $APT_CACHE_BUST" \
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20
 
-ARG SNYK_BROKER_VERSION=v1.0.13-axon
+ARG SNYK_BROKER_VERSION=v1.0.14-axon
 RUN wget -q -O - https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && apt-get install -y nodejs
 RUN npm install --global npm@latest typescript@4.9.3
 RUN git clone https://github.com/cortexapps/snyk-broker.git /tmp/snyk-broker && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,12 +21,20 @@ RUN cd /build && go build -o /agent/cortex-axon-agent
 FROM debian:stable-slim
 WORKDIR /agent
 
-# Install dependencies. libngtcp2-16, libngtcp2-crypto-gnutls8, and libnghttp2-14
-# are pinned to patched Debian versions to address CVE-2026-40170 and
-# CVE-2026-27135; they're pulled transitively via wget -> libcurl3-gnutls. Bump
-# these pins if Debian ships a newer fix or the current version ages out of the
-# archive.
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+# APT_CACHE_BUST participates in buildx's layer cache key for the RUN below.
+# Bump its value (a one-line PR is enough) to invalidate the cached layer and
+# force `apt-get update && upgrade` to re-fetch from Debian's archive. Use this
+# when the scheduled Trivy scan flags OS-package CVEs whose fixes are already
+# in the archive — the cache is just serving a stale layer. Leaves the rest of
+# the build (Go, npm, snyk-broker clone) hitting cache as normal.
+#
+# libngtcp2-16, libngtcp2-crypto-gnutls8, and libnghttp2-14 are pinned to
+# patched Debian versions for CVE-2026-40170 and CVE-2026-27135; pulled
+# transitively via wget -> libcurl3-gnutls. Bump if Debian ships a newer fix
+# or the current version ages out of the archive.
+ARG APT_CACHE_BUST=2026-05-19
+RUN echo "apt cache bust: $APT_CACHE_BUST" \
+    && apt-get update && apt-get upgrade -y && apt-get install -y \
     protobuf-compiler git python3 python3-venv wget build-essential openssl jq \
     libngtcp2-16=1.11.0-1+deb13u1 \
     libngtcp2-crypto-gnutls8=1.11.0-1+deb13u1 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,18 +27,10 @@ WORKDIR /agent
 # when the scheduled Trivy scan flags OS-package CVEs whose fixes are already
 # in the archive — the cache is just serving a stale layer. Leaves the rest of
 # the build (Go, npm, snyk-broker clone) hitting cache as normal.
-#
-# libngtcp2-16, libngtcp2-crypto-gnutls8, and libnghttp2-14 are pinned to
-# patched Debian versions for CVE-2026-40170 and CVE-2026-27135; pulled
-# transitively via wget -> libcurl3-gnutls. Bump if Debian ships a newer fix
-# or the current version ages out of the archive.
 ARG APT_CACHE_BUST=2026-05-19
 RUN echo "apt cache bust: $APT_CACHE_BUST" \
     && apt-get update && apt-get upgrade -y && apt-get install -y \
-    protobuf-compiler git python3 python3-venv wget build-essential openssl jq \
-    libngtcp2-16=1.11.0-1+deb13u1 \
-    libngtcp2-crypto-gnutls8=1.11.0-1+deb13u1 \
-    libnghttp2-14=1.64.0-1.1+deb13u1
+    protobuf-compiler git python3 python3-venv wget build-essential openssl jq
 
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20


### PR DESCRIPTION
Clears every finding from the May 18 \`:main\` Trivy scan — 11 OS-package CVEs + 1 Node-package CVE — removes the cache-staleness root cause that's been recurring since #99, and retires the per-CVE hard pins as redundant.

## Changes

1. **`docker/Dockerfile`: add `ARG APT_CACHE_BUST=2026-05-19`** referenced inside the apt `RUN`. Buildx folds ARG values into the layer cache key, so bumping this value (a one-line PR) invalidates *only* the apt layer — Go build, npm install, snyk-broker clone keep hitting cache. Future Trivy failures from stale OS packages become a one-line refresh PR.

2. **`docker/Dockerfile`: bump `SNYK_BROKER_VERSION v1.0.13-axon → v1.0.14-axon`** to pull cortexapps/snyk-broker#23, which top-level-overrides \`ws → ~8.20.1\` to address CVE-2026-45736.

3. **`docker/Dockerfile`: remove `libngtcp2-16`, `libngtcp2-crypto-gnutls8`, `libnghttp2-14` hard pins.** With APT_CACHE_BUST driving cache invalidation explicitly, \`apt-get upgrade -y\` pulls the current patched versions transitively via wget → libcurl3-gnutls without needing explicit pins. Keeping the pins would also block apt from picking up future point releases and would eventually break the build when those specific versions age out of the archive. The trivy-pr scan on this PR validates that removing them doesn't regress CVE-2026-40170 or CVE-2026-27135.

## Why this is the right shape (and what we ruled out)

Three approaches were considered for the OS-package side:

| Approach | Verdict |
|---|---|
| Hard-pin each flagged package | Treadmill — #99/#102 already showed this recurs ~weekly. PR #99's own trade-off section flagged a cleaner fix as deferred work. |
| Empty-commit PR | Tested in #105 — \`build\` log showed \`#16 CACHED\` on the apt RUN; trivy-pr still reported the same packages plus more. **An unchanged Dockerfile does not bust the cache.** |
| Remove buildx cache entirely | Works (matches brain-backend/brain-app convention), but costs ~5 min per PR build. |
| **APT_CACHE_BUST ARG** *(chosen)* | Surgical — only the apt layer invalidates on bump. Cache benefits preserved for everything else. Same effect Shawn proposed in slack ("increment a variable at a lower layer"). |

Local \`docker buildx build --no-cache\` (with the previous pinned variant) + \`trivy image\`: 0 HIGH/CRITICAL fixable findings. After this PR's pin removal, the same outcome is validated by the PR's \`trivy-pr\` job — see CI results.

## Today's findings cleared

| Finding | Cleared by |
|---|---|
| python3.13, python3.13-minimal, python3.13-venv | APT_CACHE_BUST |
| libpython3.13-stdlib, libpython3.13-minimal | APT_CACHE_BUST |
| openssh-client | APT_CACHE_BUST |
| libsystemd0, libudev1 | APT_CACHE_BUST |
| jq, libjq1 | APT_CACHE_BUST |
| libcap2 | APT_CACHE_BUST |
| ws (snyk-broker node_modules) | snyk-broker v1.0.14-axon |

## Future workflow

When the daily Trivy scan flags fresh OS-package CVEs:

1. Open a one-line PR bumping \`APT_CACHE_BUST\` to today's date.
2. PR's \`build\` job rebuilds the apt layer; \`trivy-pr\` validates the fresh image.
3. Green \`trivy-pr\` ⇒ merge ⇒ post-merge \`:main\` build is also fresh ⇒ next scheduled scan passes.

Hard pins become a last-resort tool for the rare case where \`apt-get upgrade\` doesn't pull a patched version even with a fresh layer (none today).

## Test plan

- [ ] PR's \`build\` job log shows the apt RUN is *not* \`CACHED\` (contrast with #105 where it was)
- [ ] \`trivy-pr\` on this PR reports 0 HIGH/CRITICAL findings
- [ ] After merge, daily \`:main\` scan passes
- [ ] Cut a release tag from main HEAD; tag image is fresh

## Related

- cortexapps/snyk-broker#23 — ws top-level override (merged, tagged v1.0.14-axon)
- #99 — pin libngtcp2 for CVE-2026-40170 (notes this fix as deferred option)
- #102 — pin libnghttp2 for CVE-2026-27135
- #105 — empty-commit experiment confirming the cache hypothesis (close after this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)