### PR TITLE
fix(deps): bump APT_CACHE_BUST to clear 8 OS-package CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN echo "apt cache bust: $APT_CACHE_BUST" \
 # Install NodeJS and Snyk Broker
 ENV NODE_VERSION=20
 
-ARG SNYK_BROKER_VERSION=v1.0.14-axon
+ARG SNYK_BROKER_VERSION=v1.0.15-axon
 RUN wget -q -O - https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && apt-get install -y nodejs
 RUN npm install --global npm@latest typescript@4.9.3
 RUN git clone https://github.com/cortexapps/snyk-broker.git /tmp/snyk-broker && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /agent
 # when the scheduled Trivy scan flags OS-package CVEs whose fixes are already
 # in the archive — the cache is just serving a stale layer. Leaves the rest of
 # the build (Go, npm, snyk-broker clone) hitting cache as normal.
-ARG APT_CACHE_BUST=2026-05-19
+ARG APT_CACHE_BUST=2026-05-27
 RUN echo "apt cache bust: $APT_CACHE_BUST" \
     && apt-get update && apt-get upgrade -y && apt-get install -y \
     protobuf-compiler git python3 python3-venv wget build-essential openssl jq


### PR DESCRIPTION
Automated triage of [Trivy scan run #26509407170](https://github.com/cortexapps/axon/actions/runs/26509407170/job/78070027903) (scheduled `:main` scan, 8 CRITICAL/HIGH fixable findings).

## Commits

**1. Bump `APT_CACHE_BUST` (`2026-05-19` → `2026-05-27`)** — clears the 8 OS-package CVEs. All have fixes already in the Debian archive; per the convention in #104, bumping the ARG invalidates the cached apt layer so `apt-get update && upgrade -y` re-fetches them transitively (no pins).

| CVE | Severity | Package(s) | Installed | Fixed |
|-----|----------|------------|-----------|-------|
| CVE-2026-40356 | HIGH | krb5-locales, libgssapi-krb5-2, libk5crypto3, libkrb5-3, libkrb5support0 | 1.21.3-5 | 1.21.3-5+deb13u1 |
| CVE-2026-23171 | HIGH | linux-libc-dev | 6.12.88-1 | 6.12.90-1 |
| CVE-2026-43503 | HIGH | linux-libc-dev | 6.12.88-1 | 6.12.90-1 |
| CVE-2026-46300 | HIGH | linux-libc-dev | 6.12.88-1 | 6.12.90-1 |

**2. Bump `SNYK_BROKER_VERSION` (`v1.0.14-axon` → `v1.0.15-axon`)** — clears the `qs` finding the first commit's rebuild surfaced (the stale `:main` image was hiding it).

| CVE | Severity | Package | Fix |
|-----|----------|---------|-----|
| CVE-2026-8723 | HIGH | qs (6.15.0 → 6.15.2) | snyk-broker#24, released as v1.0.15-axon |

## Verification

- First `trivy-pr` run ([#26528256403](https://github.com/cortexapps/axon/actions/runs/26528256403/job/78138274502)) confirmed all 8 OS CVEs cleared, leaving only `qs`.
- The snyk-broker fix was verified locally (minimal `node:20-slim` image → `qs` resolves to 6.15.2, zero Trivy findings) before tagging.
- This PR's `trivy-pr` scan now validates both commits together — expected fully green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)