### PR TITLE
Add pprof profiling endpoint on main HTTP port under /pprof

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -96,6 +96,7 @@
                 "SCAFFOLD_DOCKER_IMAGE": "cortex-axon-agent:local",
                 "PORT" : "7399",
                 "BUILTIN_PLUGIN_DIR": "${workspaceFolder}/agent/server/snykbroker/plugins",
+                "ENABLE_PPROF": "true"
             }        
         },
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -72,6 +72,7 @@ type AgentConfig struct {
 	WebhookServerPort     int
 	SnykBrokerPort        int
 	EnableApiProxy        bool
+	EnablePprof           bool
 	FailWaitTime          time.Duration
 	AutoRegisterFrequency time.Duration
 	VerboseOutput         bool
@@ -108,6 +109,9 @@ func (ac AgentConfig) Print() {
 		fmt.Println("\tAPI Port: ", ac.HttpServerPort)
 	} else {
 		fmt.Println("\tAPI Proxy: Disabled")
+	}
+	if ac.EnablePprof {
+		fmt.Println("\tpprof: Enabled at /pprof")
 	}
 
 	fmt.Printf("\tFast fail time: %v\n", ac.FailWaitTime)
@@ -180,6 +184,11 @@ func NewAgentEnvConfig() AgentConfig {
 		dryRun = dryRunEnv == "true" || dryRunEnv == "1"
 	}
 
+	enablePprof := false
+	if pprofEnv := os.Getenv("ENABLE_PPROF"); pprofEnv != "" {
+		enablePprof = pprofEnv == "true" || pprofEnv == "1"
+	}
+
 	dequeueWaitTime := 1 * time.Second
 	if dequeueWaitTimeEnv := os.Getenv("DEQUEUE_WAIT_TIME"); dequeueWaitTimeEnv != "" {
 		dwt, err := time.ParseDuration(dequeueWaitTimeEnv)
@@ -243,6 +252,7 @@ func NewAgentEnvConfig() AgentConfig {
 		WebhookServerPort:          WebhookServerPort,
 		SnykBrokerPort:             snykBrokerPort,
 		EnableApiProxy:             true,
+		EnablePprof:                enablePprof,
 		FailWaitTime:               time.Second * 2,
 		PluginDirs:                 []string{"./plugins"},
 		AutoRegisterFrequency:      reregisterFrequency,

--- a/agent/server/http/pprof_handler.go
+++ b/agent/server/http/pprof_handler.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"io"
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/cortexapps/axon/config"
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+)
+
+const PprofPathRoot = "/pprof"
+
+type pprofHandler struct {
+	io.Closer
+	config config.AgentConfig
+	logger *zap.Logger
+}
+
+func NewPprofHandler(config config.AgentConfig, logger *zap.Logger) RegisterableHandler {
+	return &pprofHandler{
+		config: config,
+		logger: logger,
+	}
+}
+
+func (h *pprofHandler) RegisterRoutes(m *mux.Router) error {
+	sub := m.PathPrefix(PprofPathRoot).Subrouter()
+
+	// The index page generates relative links to the named profiles, so they
+	// resolve under /pprof/. Individual profiles must be registered explicitly
+	// since pprof.Index only auto-dispatches under the hardcoded /debug/pprof/.
+	sub.HandleFunc("/", pprof.Index)
+	sub.HandleFunc("/cmdline", pprof.Cmdline)
+	sub.HandleFunc("/profile", pprof.Profile)
+	sub.HandleFunc("/symbol", pprof.Symbol)
+	sub.HandleFunc("/trace", pprof.Trace)
+
+	for _, name := range []string{"heap", "goroutine", "allocs", "block", "mutex", "threadcreate"} {
+		sub.Handle("/"+name, pprof.Handler(name))
+	}
+
+	h.logger.Info("pprof profiling endpoint enabled", zap.String("path", PprofPathRoot))
+
+	return nil
+}
+
+func (h *pprofHandler) ServeHTTP(_ http.ResponseWriter, _ *http.Request) {
+	panic("ServeHTTP should not be called directly")
+}

--- a/agent/server/http/pprof_handler_test.go
+++ b/agent/server/http/pprof_handler_test.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cortexapps/axon/config"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newPprofTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	handler := NewPprofHandler(config.AgentConfig{}, zap.NewNop())
+	router := mux.NewRouter()
+	require.NoError(t, handler.RegisterRoutes(router))
+	ts := httptest.NewServer(router)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestPprofIndex(t *testing.T) {
+	ts := newPprofTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/pprof/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "goroutine")
+}
+
+func TestPprofHeapProfile(t *testing.T) {
+	ts := newPprofTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/pprof/heap")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, body)
+}

--- a/agent/server/main_http_server.go
+++ b/agent/server/main_http_server.go
@@ -54,5 +54,10 @@ func NewMainHttpServer(p MainHttpServerParams) cortexHttp.Server {
 		httpServer.RegisterHandler(metricsHandler)
 	}
 
+	if config.EnablePprof {
+		pprofHandler := cortexHttp.NewPprofHandler(config, p.Logger)
+		httpServer.RegisterHandler(pprofHandler)
+	}
+
 	return httpServer
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /agent
 # when the scheduled Trivy scan flags OS-package CVEs whose fixes are already
 # in the archive — the cache is just serving a stale layer. Leaves the rest of
 # the build (Go, npm, snyk-broker clone) hitting cache as normal.
-ARG APT_CACHE_BUST=2026-05-27
+ARG APT_CACHE_BUST=2026-05-29
 RUN echo "apt cache bust: $APT_CACHE_BUST" \
     && apt-get update && apt-get upgrade -y && apt-get install -y \
     protobuf-compiler git python3 python3-venv wget build-essential openssl jq


### PR DESCRIPTION
## Summary

Exposes Go's standard `net/http/pprof` handlers on the main HTTP port (`HTTP_PORT` / `DefaultHttpPort`) under `/pprof`, so operators can collect heap dumps, CPU profiles, and goroutine stacks from a running agent.

Gated behind a new **`ENABLE_PPROF`** env flag (default **off**), mirroring the existing `EnableApiProxy` pattern. Routes register only when the flag is set — pprof exposes sensitive runtime data (raw memory, goroutine stacks) and the main HTTP port has no auth on any route today.

## Changes

- **`agent/config/config.go`** — new `EnablePprof bool` field, parsed from `ENABLE_PPROF` (`"true"`/`"1"`, default `false`); shown in `Print()` when enabled.
- **`agent/server/http/pprof_handler.go`** (new) — a `RegisterableHandler` (same pattern as `metricsHandler`) that mounts a `/pprof` subrouter wiring the standard pprof entry points (`/`, `/cmdline`, `/profile`, `/symbol`, `/trace`) plus named profiles (`heap`, `goroutine`, `allocs`, `block`, `mutex`, `threadcreate`). Logs an info line when enabled.
- **`agent/server/main_http_server.go`** — conditional registration: `if config.EnablePprof { ... }`.
- **`agent/server/http/pprof_handler_test.go`** (new) — httptest-based coverage of the index page and heap profile.
- **`.vscode/launch.json`** — sets `ENABLE_PPROF=true` for the local debug config.

## Usage

Start the agent with `ENABLE_PPROF=true`, then:
- `curl http://localhost:$HTTP_PORT/pprof/` — profile index
- `go tool pprof http://localhost:$HTTP_PORT/pprof/heap` — memory profile
- `go tool pprof http://localhost:$HTTP_PORT/pprof/profile?seconds=5` — CPU profile

## Testing

- `go build ./...` — compiles
- `go test ./server/http/... ./config/...` — passes

## Security note

Since the main HTTP port has no auth on any route, keep `ENABLE_PPROF` off in environments where the port is publicly reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)