### PR TITLE
fix(deps): bump Go toolchain to 1.26.4 for CVE-2026-42504

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/cortexapps/axon
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stable-slim AS builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y protobuf-compiler git wget build-essential
 
-ENV GOLANG_VERSION=1.26.3
+ENV GOLANG_VERSION=1.26.4
 RUN wget -q "https://dl.google.com/go/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz" -O /tmp/go.tar.gz \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz
@@ -52,7 +52,7 @@ RUN git clone https://github.com/cortexapps/snyk-broker.git /tmp/snyk-broker && 
 ENV PATH="/usr/local/lib/node_modules/.bin:${PATH}"
 
 # Install Go (needed by scaffold apps that build on top of this image)
-ENV GOLANG_VERSION=1.26.3
+ENV GOLANG_VERSION=1.26.4
 RUN wget -q "https://dl.google.com/go/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz" -O /tmp/go.tar.gz \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz

--- a/scaffold/go/go.mod
+++ b/scaffold/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/cortexapps/axon_apps/{{.ProjectName}}
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/cortexapps/axon-go
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Automated triage of the [failed Trivy scan run](https://github.com/cortexapps/axon/actions/runs/27060716545/job/79873004401).

## Auto-applied fixes (1)

| CVE | Severity | Package | From | To | File(s) |
|-----|----------|---------|------|----|---------|
| CVE-2026-42504 | HIGH | stdlib (Go toolchain) | 1.26.3 | 1.26.4 | `docker/Dockerfile` (×2), `agent/go.mod`, `scaffold/go/go.mod`, `sdks/go/go.mod` |

The CVE is in the Go standard library compiled into the agent binary. Trivy reads the
stdlib version from the binary, which is set by the Go compiler installed via
`GOLANG_VERSION` in the Dockerfile. Patch-level bump on the same minor line (1.26.x),
lowest fixed version ≥ installed — minimal blast radius. The `go` directives in all
three modules are bumped to match (mirrors #101 which bumped them together to 1.26.3).

## Verification

- `go build ./...` in `sdks/go` passes on go1.26.4.
- `agent/` build error (`.generated/proto/...` missing) is **pre-existing** — that dir is
  gitignored codegen output, unrelated to this bump.
- `scaffold/go/go.mod` is a Go template (`{{.ProjectName}}`); only the `go` directive changed.

---
*Draft so a human marks ready. CI on this PR validates the bump before merge.*
